### PR TITLE
Add authentication with bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Download sketch ID `2063664` to a folder named `sketch_2063664`:
 npx opdl 2063664
 ```
 
+> **Note:** All API requests require a Bearer token. Generate one from your [OpenProcessing account settings](https://openprocessing.org/profile/#settings) and configure it before use (see [Authentication](#authentication)).
+
 ## Installation
 
 With npm:
@@ -31,6 +33,46 @@ With bun:
 ```bash
 bun install -g opdl
 ```
+
+## Authentication
+
+All requests to the OpenProcessing API require a Bearer token. Generate one from your [OpenProcessing account settings](https://openprocessing.org/profile/#settings).
+
+### Save your token (recommended)
+
+```bash
+opdl auth --token YOUR_API_TOKEN
+```
+
+This writes the token to `~/.opdlrc` so every subsequent `opdl` command picks it up automatically.
+
+```bash
+opdl auth            # check token status
+opdl auth --clear    # remove saved token
+```
+
+### Environment variable
+
+```bash
+export OP_API_KEY=YOUR_API_TOKEN
+opdl 2063664
+```
+
+Useful for CI/CD pipelines or when you prefer not to write the token to disk.
+
+### One-off flag
+
+```bash
+opdl 2063664 --token YOUR_API_TOKEN
+```
+
+### Resolution order
+
+When a command runs, the token is resolved in this priority order:
+
+1. `--token` flag (highest)
+2. `OP_API_KEY` environment variable
+3. `token` in `~/.opdlrc`
 
 ## Usage
 
@@ -80,7 +122,7 @@ See the [documentation](HELP.md) file for a full list of CLI options and flags.
 const opdl = require('opdl');
 
 (async () => {
-  const result = await opdl('2063664');
+  const result = await opdl('2063664', { token: process.env.OP_API_KEY });
 
   if (result.success) {
     console.log(`Downloaded sketch: ${result.sketchInfo.title} by ${result.sketchInfo.author}`);
@@ -97,7 +139,7 @@ const opdl = require('opdl');
 const { OpenProcessingClient } = require('opdl');
 
 (async () => {
-  const client = new OpenProcessingClient();
+  const client = new OpenProcessingClient(process.env.OP_API_KEY);
 
   // Get sketch details
   const sketch = await client.getSketch(2063664);
@@ -166,11 +208,49 @@ sketch_{id}/
 - Private sketches and sketches with hidden code abort the download and populate `sketchInfo.error` with details.
 - Network or file-system errors populate `sketchInfo.error` while still returning a structured result.
 - Asset-download failures are logged (unless `quiet: true`) but do not abort the operation.
-- **Rate Limiting**: The OpenProcessing API has a rate limit of 40 calls per minute. When exceeded, you'll receive a descriptive error message with retry guidance.
+- **Rate Limiting**: The OpenProcessing API has dynamic rate-limits that depend on your account type. When exceeded, you'll receive a descriptive error message with retry guidance.
 
 ## Attribution
 
 All downloads preserve the original licensing information. `LICENSE` reflects Creative Commons licenses when provided, and `OPENPROCESSING.md` records metadata, tags, and library dependencies. Attribution comments at the top of each code file explain the sketch origin and link back to OpenProcessing.
+
+## Development
+
+### Running locally
+
+Clone the repo and install dependencies:
+
+```bash
+git clone https://github.com/SableRaf/opdl.git
+cd opdl
+npm install
+```
+
+Link the package globally so the `opdl` command runs your local source. 
+
+From the project root directory, run:
+
+```bash
+npm link
+```
+
+You can now run `opdl` from anywhere and it will use your local changes. To unlink when you're done:
+
+```bash
+npm unlink -g opdl
+```
+
+### Running tests
+
+```bash
+npm test
+```
+
+Tests use [Vitest](https://vitest.dev/) and include a live API integration test that makes real requests to OpenProcessing. Set `OP_API_KEY` before running tests to avoid rate limiting:
+
+```bash
+OP_API_KEY=YOUR_API_TOKEN npm test
+```
 
 ## Thanks
 Thanks to Sinan Ascioglu for creating OpenProcessing and providing the API at https://openprocessing.org/api

--- a/bin/opdl.js
+++ b/bin/opdl.js
@@ -7,6 +7,7 @@ const { handleFieldsCommand } = require(path.join(__dirname, '..', 'src', 'cli',
 const { handleSketchCommand } = require(path.join(__dirname, '..', 'src', 'cli', 'commands', 'sketch.js'));
 const { handleUserCommand } = require(path.join(__dirname, '..', 'src', 'cli', 'commands', 'user.js'));
 const { handleCurationCommand } = require(path.join(__dirname, '..', 'src', 'cli', 'commands', 'curation.js'));
+const { handleAuthCommand } = require(path.join(__dirname, '..', 'src', 'cli', 'commands', 'auth.js'));
 
 /**
  * Main CLI entry point
@@ -30,6 +31,10 @@ async function main() {
     const parsed = parseArgs(argv);
 
     switch (parsed.command) {
+      case 'auth':
+        handleAuthCommand(parsed.options);
+        break;
+
       case 'fields':
         await handleFieldsCommand({
           fieldSetName: parsed.id,
@@ -87,6 +92,11 @@ USAGE:
 
 COMMANDS:
 
+  Authentication:
+    opdl auth --token <token>             Save API token to ~/.opdlrc
+    opdl auth --clear                     Remove saved token
+    opdl auth                             Show token status
+
   Field Discovery:
     opdl fields                           List all available field sets
     opdl fields <fieldSet>                Show fields for a specific field set
@@ -118,6 +128,9 @@ OPTIONS:
     --limit <n>            Limit number of results
     --offset <n>           Skip first n results
     --sort <asc|desc>      Sort order
+
+  Authentication:
+    --token <value>        API bearer token (overrides OP_API_KEY and ~/.opdlrc)
 
   Download Options (for sketch download):
     --outputDir <path>     Output directory for files
@@ -152,7 +165,12 @@ EXAMPLES:
   opdl curation sketches 12 --limit 20 --sort desc
 
 ENVIRONMENT:
-  OP_API_KEY    OpenProcessing API key (if required)
+  OP_API_KEY    OpenProcessing API bearer token
+
+TOKEN RESOLUTION (highest to lowest priority):
+  1. --token <value> flag
+  2. OP_API_KEY environment variable
+  3. token field in ~/.opdlrc (set via: opdl auth --token <value>)
 
 For more information, visit: https://github.com/SableRaf/opdl
 `);

--- a/src/api/validator.js
+++ b/src/api/validator.js
@@ -15,7 +15,7 @@ const VALIDATION_REASONS = {
 
 // Standard error messages
 const MESSAGES = {
-  PRIVATE_SKETCH: 'This sketch is private and cannot be downloaded.',
+  PRIVATE_SKETCH: 'This sketch is private and cannot be downloaded without the creator\'s authentication token.',
   HIDDEN_CODE: 'The source code for this sketch is hidden by the author.',
   NOT_FOUND_SKETCH: 'Sketch not found.',
   NOT_FOUND_USER: 'User not found.',

--- a/src/cli/commands/auth.js
+++ b/src/cli/commands/auth.js
@@ -1,0 +1,37 @@
+const { readConfig, writeConfig, CONFIG_PATH } = require('../../config');
+
+/**
+ * Handle auth-related commands
+ * @param {Object} args
+ * @param {string} [args.token] - Token to save (from --token flag)
+ * @param {boolean} [args.clear] - Remove saved token
+ */
+function handleAuthCommand(args) {
+  if (args.clear) {
+    const config = readConfig();
+    delete config.token;
+    writeConfig(config);
+    console.log('Token cleared from', CONFIG_PATH);
+    return;
+  }
+
+  if (args.token) {
+    const config = readConfig();
+    config.token = args.token;
+    writeConfig(config);
+    console.log('Token saved to', CONFIG_PATH);
+    return;
+  }
+
+  // Status check
+  const config = readConfig();
+  if (config.token) {
+    console.log('Token is configured in', CONFIG_PATH);
+  } else if (process.env.OP_API_KEY) {
+    console.log('Token is configured via OP_API_KEY environment variable');
+  } else {
+    console.log('No token configured. Use: opdl auth --token <your-token>');
+  }
+}
+
+module.exports = { handleAuthCommand };

--- a/src/cli/commands/curation.js
+++ b/src/cli/commands/curation.js
@@ -2,6 +2,7 @@ const { OpenProcessingClient } = require('../../api/client');
 const { selectFields } = require('../fieldSelector');
 const { formatObject, formatArray } = require('../formatters');
 const { validateId } = require('../../api/validator');
+const { getToken } = require('../../config');
 
 /**
  * Handle curation-related commands
@@ -11,7 +12,7 @@ const { validateId } = require('../../api/validator');
  * @param {Object} args.options - Command options
  */
 async function handleCurationCommand(args) {
-  const client = new OpenProcessingClient(process.env.OP_API_KEY);
+  const client = new OpenProcessingClient(getToken(args.options.token));
 
   // Validate curation ID
   const idValidation = validateId(args.id);

--- a/src/cli/commands/sketch.js
+++ b/src/cli/commands/sketch.js
@@ -3,6 +3,7 @@ const { selectFields } = require('../fieldSelector');
 const { formatObject } = require('../formatters');
 const { validateId } = require('../../api/validator');
 const opdl = require('../../index');
+const { getToken } = require('../../config');
 
 /**
  * Handle sketch-related commands
@@ -12,7 +13,8 @@ const opdl = require('../../index');
  * @param {Object} args.options - Command options
  */
 async function handleSketchCommand(args) {
-  const client = new OpenProcessingClient(process.env.OP_API_KEY);
+  const token = getToken(args.options.token);
+  const client = new OpenProcessingClient(token);
 
   // Validate sketch ID
   const idValidation = validateId(args.id);
@@ -22,10 +24,8 @@ async function handleSketchCommand(args) {
   const sketchId = idValidation.data;
 
   if (args.subcommand === 'info' || args.options.info) {
-    // Get sketch metadata (client validates the response)
     const sketch = await client.getSketch(sketchId);
 
-    // Select fields if --info specified
     let output = sketch;
     if (args.options.info) {
       output = selectFields(sketch, {
@@ -34,12 +34,10 @@ async function handleSketchCommand(args) {
       });
     }
 
-    // Format and print
     if (!args.options.quiet) {
       console.log(formatObject(output, { json: args.options.json }));
     }
   } else {
-    // Download sketch (use existing opdl functionality)
     const downloadOptions = {
       outputDir: args.options.outputDir,
       downloadAssets: !args.options.skipAssets,
@@ -53,7 +51,7 @@ async function handleSketchCommand(args) {
       run: args.options.run || false,
     };
 
-    const result = await opdl(sketchId, downloadOptions);
+    const result = await opdl(sketchId, { ...downloadOptions, token });
 
     if (!result.success) {
       throw new Error(result.sketchInfo.error || 'Failed to download sketch');

--- a/src/cli/commands/sketch.js
+++ b/src/cli/commands/sketch.js
@@ -47,6 +47,7 @@ async function handleSketchCommand(args) {
       createLicenseFile: true,
       createOpMetadata: true,
       quiet: args.options.quiet || false,
+      verbose: args.options.verbose || false,
       vite: args.options.vite || false,
       run: args.options.run || false,
     };

--- a/src/cli/commands/user.js
+++ b/src/cli/commands/user.js
@@ -2,6 +2,7 @@ const { OpenProcessingClient } = require('../../api/client');
 const { selectFields } = require('../fieldSelector');
 const { formatObject, formatArray } = require('../formatters');
 const { validateId } = require('../../api/validator');
+const { getToken } = require('../../config');
 
 /**
  * Handle user-related commands
@@ -11,7 +12,7 @@ const { validateId } = require('../../api/validator');
  * @param {Object} args.options - Command options
  */
 async function handleUserCommand(args) {
-  const client = new OpenProcessingClient(process.env.OP_API_KEY);
+  const client = new OpenProcessingClient(getToken(args.options.token));
 
   // Validate user ID
   const idValidation = validateId(args.id);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -37,6 +37,14 @@ function parseArgs(argv) {
     throw new Error('No command provided');
   }
 
+  // Handle: opdl auth [--token <token>] [--clear]
+  if (argv[0] === 'auth') {
+    return {
+      command: 'auth',
+      options: parseOptions(argv.slice(1)),
+    };
+  }
+
   // Handle: opdl fields [fieldSetName]
   if (argv[0] === 'fields') {
     return {
@@ -144,6 +152,7 @@ function parseOptions(args) {
     // Boolean flags
     if (arg === '--json') options.json = true;
     else if (arg === '--quiet') options.quiet = true;
+    else if (arg === '--clear') options.clear = true;
     else if (arg === '--downloadThumbnail') options.downloadThumbnail = true;
     else if (arg === '--saveMetadata') options.saveMetadata = true;
     else if (arg === '--downloadAssets') options.downloadAssets = true;
@@ -157,7 +166,9 @@ function parseOptions(args) {
     else if (arg === '--vite') options.vite = true;
     else if (arg === '--run') options.run = true;
     // Value flags with = syntax
-    else if (arg.startsWith('--info=')) {
+    else if (arg.startsWith('--token=')) {
+      options.token = arg.split('=')[1];
+    } else if (arg.startsWith('--info=')) {
       options.info = arg.split('=')[1];
     } else if (arg.startsWith('--outputDir=')) {
       options.outputDir = arg.split('=')[1];
@@ -169,7 +180,9 @@ function parseOptions(args) {
       options.sort = arg.split('=')[1];
     }
     // Value flags with space syntax
-    else if (arg === '--info') {
+    else if (arg === '--token') {
+      options.token = args[++i];
+    } else if (arg === '--info') {
       options.info = args[++i];
     } else if (arg === '--outputDir') {
       options.outputDir = args[++i];

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -25,6 +25,7 @@
  * @property {boolean} [options.createOpMetadata] - Create OP metadata file
  * @property {boolean} [options.vite] - Set up Vite project structure
  * @property {boolean} [options.run] - Automatically run dev server after scaffolding
+ * @property {boolean} [options.verbose] - Print detailed download info and error diagnostics
  */
 
 /**
@@ -165,6 +166,7 @@ function parseOptions(args) {
     else if (arg === '--skipOpMetadata') options.createOpMetadata = false;
     else if (arg === '--vite') options.vite = true;
     else if (arg === '--run') options.run = true;
+    else if (arg === '--verbose') options.verbose = true;
     // Value flags with = syntax
     else if (arg.startsWith('--token=')) {
       options.token = arg.split('=')[1];

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const CONFIG_PATH = path.join(os.homedir(), '.opdlrc');
+
+function readConfig() {
+  try {
+    return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeConfig(data) {
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(data, null, 2) + '\n', 'utf8');
+}
+
+/**
+ * Resolve the API token from (in priority order):
+ * 1. cliToken  — from --token flag
+ * 2. OP_API_KEY env var
+ * 3. token field in ~/.opdlrc
+ *
+ * @param {string} [cliToken]
+ * @returns {string|undefined}
+ */
+function getToken(cliToken) {
+  return cliToken || process.env.OP_API_KEY || readConfig().token;
+}
+
+module.exports = { getToken, readConfig, writeConfig, CONFIG_PATH };

--- a/src/download/downloader.js
+++ b/src/download/downloader.js
@@ -77,6 +77,9 @@ const downloadSketch = async (sketchInfo, options = {}) => {
         }
 
         try {
+          if (finalOptions.verbose) {
+            console.log(`opdl: downloading asset ${filename} from ${assetUrl}`);
+          }
           const response = await axios.get(assetUrl, { responseType: 'arraybuffer' });
           const assetFileName = sanitizeFilename(filename) || path.basename(filename);
           const assetFilePath = path.join(outputDir, assetFileName);
@@ -84,6 +87,11 @@ const downloadSketch = async (sketchInfo, options = {}) => {
         } catch (error) {
           if (!finalOptions.quiet) {
             console.warn(`opdl: failed to download asset ${filename}`);
+            if (finalOptions.verbose) {
+              console.warn(`  URL: ${assetUrl}`);
+              console.warn(`  Status: ${error.response?.status ?? 'no response'}`);
+              console.warn(`  Error: ${error.message}`);
+            }
           }
         }
       }
@@ -99,16 +107,26 @@ const downloadSketch = async (sketchInfo, options = {}) => {
   }
 
   if (finalOptions.downloadThumbnail && sketchInfo.metadata?.visualID) {
+    const thumbnailUrl = THUMBNAIL_URL_TEMPLATE.replace('{visualID}', sketchInfo.metadata.visualID);
     try {
-      const thumbnailUrl = THUMBNAIL_URL_TEMPLATE.replace('{visualID}', sketchInfo.metadata.visualID);
+      if (finalOptions.verbose) {
+        console.log(`opdl: downloading thumbnail from ${thumbnailUrl}`);
+      }
       const response = await axios.get(thumbnailUrl, { responseType: 'arraybuffer' });
       const thumbnailPath = path.join(metadataDir, 'thumbnail.jpg');
       fs.writeFileSync(thumbnailPath, response.data);
     } catch (error) {
       if (!finalOptions.quiet) {
         console.warn('opdl: unable to download thumbnail');
+        if (finalOptions.verbose) {
+          console.warn(`  URL: ${thumbnailUrl}`);
+          console.warn(`  Status: ${error.response?.status ?? 'no response'}`);
+          console.warn(`  Error: ${error.message}`);
+        }
       }
     }
+  } else if (finalOptions.downloadThumbnail && finalOptions.verbose) {
+    console.log('opdl: skipping thumbnail — no visualID in metadata');
   }
 
   if (sketchInfo.metadata?.mode && sketchInfo.metadata.mode !== 'html') {

--- a/src/download/downloader.js
+++ b/src/download/downloader.js
@@ -9,9 +9,7 @@ const { createLicenseFile } = require('./licenseHandler');
 const { createOpMetadata } = require('./metadataWriter');
 
 const META_DIR = 'metadata';
-const THUMBNAIL_URL_TEMPLATE = 'https://openprocessing-usercontent.s3.amazonaws.com/thumbnails/visualThumbnail{visualID}@2x.jpg';
-// TODO: Handle modern OpenProcessing thumbnail URL pattern
-// https://kyoko.openprocessing.org/thumbnails/visualThumbnail{visualID}@2x.jpg
+const THUMBNAIL_URL_TEMPLATE = 'https://kyoko.openprocessing.org/thumbnails/visualThumbnail{visualID}@2x.jpg';
 
 const downloadSketch = async (sketchInfo, options = {}) => {
   const finalOptions = { ...options };

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -8,9 +8,10 @@ const logError = (message, quiet) => {
 };
 
 const fetchData = async (url, description, options = {}) => {
-  const { quiet = false } = options;
+  const { quiet = false, token } = options;
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
   try {
-    const response = await axios.get(url, { validateStatus: () => true });
+    const response = await axios.get(url, { headers, validateStatus: () => true });
     const responseData = response.data;
     if (!responseData) {
       const message = `Unexpected response format for ${description}`;
@@ -32,11 +33,9 @@ const fetchData = async (url, description, options = {}) => {
 
 
 const fetchCodeResponse = async (sketchId, options = {}) => {
-  const { quiet = false } = options;
-  const { data: responseData, error } = await fetchData(`https://openprocessing.org/api/sketch/${sketchId}/code`, `sketch code ${sketchId}`, { quiet });
+  const { quiet = false, token } = options;
+  const { data: responseData, error } = await fetchData(`https://openprocessing.org/api/sketch/${sketchId}/code`, `sketch code ${sketchId}`, { quiet, token });
 
-  // Validate responseData if it exists, regardless of error field
-  // This allows proper categorization of errors (private, hidden code, etc.)
   if (responseData) {
     const validation = validateSketch(responseData, { type: 'code' });
 
@@ -50,12 +49,10 @@ const fetchCodeResponse = async (sketchId, options = {}) => {
     return { codeParts: validation.data, error: '' };
   }
 
-  // Only return the error string if responseData is null
   if (error) {
     return { codeParts: [], error };
   }
 
-  // This should not be reached, but handle it just in case
   return { codeParts: [], error: 'Unexpected response format' };
 };
 
@@ -63,7 +60,8 @@ const fetchUserInfo = async (userId, options = {}) => {
   if (!userId) {
     return {};
   }
-  const { data, error } = await fetchData(`https://openprocessing.org/api/user/${userId}`, `user ${userId}`, options);
+  const { quiet, token } = options;
+  const { data, error } = await fetchData(`https://openprocessing.org/api/user/${userId}`, `user ${userId}`, { quiet, token });
   if (error) {
     return {}; 
   }
@@ -71,7 +69,7 @@ const fetchUserInfo = async (userId, options = {}) => {
 };
 
 const fetchSketchInfo = async (sketchId, options = {}) => {
-  const { quiet = false } = options;
+  const { quiet = false, token } = options;
   const parsedId = Number(sketchId);
   if (!Number.isFinite(parsedId) || parsedId <= 0) {
     return null;
@@ -110,7 +108,7 @@ const fetchSketchInfo = async (sketchId, options = {}) => {
   };
 
   // Fetch metadata
-  const { data: metadata } = await fetchData(`https://openprocessing.org/api/sketch/${parsedId}`, `metadata of sketch ${parsedId}`, { quiet });
+  const { data: metadata } = await fetchData(`https://openprocessing.org/api/sketch/${parsedId}`, `metadata of sketch ${parsedId}`, { quiet, token });
 
   // Validate metadata
   const metadataValidation = validateSketch(metadata, { type: 'metadata' });
@@ -128,32 +126,32 @@ const fetchSketchInfo = async (sketchId, options = {}) => {
     sketchInfo.parent.sketchID = metadata.parentID || null;
   }
 
-  // Fetch parent metadata if fork
-  if (sketchInfo.isFork && sketchInfo.parent.sketchID) {
-    const { data: parentMetadata } = await fetchData(`https://openprocessing.org/api/sketch/${sketchInfo.parent.sketchID}`, `parent sketch ${sketchInfo.parent.sketchID}`, { quiet });
+  const fetchOptions = { quiet, token };
 
-    if (parentMetadata) {
-      sketchInfo.parent.title = parentMetadata.title || '';
-      const parentUser = await fetchUserInfo(parentMetadata.userID, { quiet });
-      sketchInfo.parent.author = parentUser.fullname || '';
-    }
+  const [parentResult, userResult, codeResponse, assetsResult, librariesResult] = await Promise.all([
+    sketchInfo.isFork && sketchInfo.parent.sketchID
+      ? fetchData(`https://openprocessing.org/api/sketch/${sketchInfo.parent.sketchID}`, `parent sketch ${sketchInfo.parent.sketchID}`, fetchOptions)
+      : Promise.resolve({ data: null }),
+    sketchInfo.metadata.userID
+      ? fetchData(`https://openprocessing.org/api/user/${sketchInfo.metadata.userID}`, `user ${sketchInfo.metadata.userID}`, fetchOptions)
+      : Promise.resolve({ data: null }),
+    fetchCodeResponse(parsedId, fetchOptions),
+    fetchData(`https://openprocessing.org/api/sketch/${parsedId}/files?limit=100&offset=0`, `assets for sketch ${parsedId}`, fetchOptions),
+    fetchData(`https://openprocessing.org/api/sketch/${parsedId}/libraries?limit=100&offset=0`, `libraries for sketch ${parsedId}`, fetchOptions),
+  ]);
+
+  if (parentResult.data) {
+    sketchInfo.parent.title = parentResult.data.title || '';
+    const parentUser = await fetchUserInfo(parentResult.data.userID, fetchOptions);
+    sketchInfo.parent.author = parentUser.fullname || '';
   }
 
-  // Fetch user info
-  if (sketchInfo.metadata.userID) {
-    const { data: user } = await fetchData(`https://openprocessing.org/api/user/${sketchInfo.metadata.userID}`, `user ${sketchInfo.metadata.userID}`, { quiet });
-
-    if (user) {
-      sketchInfo.author = user.fullname || '';
-    }
+  if (userResult.data) {
+    sketchInfo.author = userResult.data.fullname || '';
   }
 
-  // Fetch code
-  const codeResponse = await fetchCodeResponse(parsedId, { quiet });
   sketchInfo.codeParts = codeResponse.codeParts || [];
   if (codeResponse.error) {
-    // Note: fetchCodeResponse now properly validates and categorizes errors
-    // Check the error message to determine if it indicates unavailability
     const isPrivateError = codeResponse.error === MESSAGES.PRIVATE_SKETCH;
     const isHiddenError = codeResponse.error === MESSAGES.HIDDEN_CODE;
 
@@ -166,22 +164,18 @@ const fetchSketchInfo = async (sketchId, options = {}) => {
     }
   }
 
-  // Fetch assets
-  const { data: assets, error: assetsError } = await fetchData(`https://openprocessing.org/api/sketch/${parsedId}/files?limit=100&offset=0`, `assets for sketch ${parsedId}`, { quiet });
-  if (assetsError) {
-    setError(assetsError);
+  if (assetsResult.error) {
+    setError(assetsResult.error);
   }
-  if (assets) {
-    sketchInfo.files = assets;
+  if (assetsResult.data) {
+    sketchInfo.files = assetsResult.data;
   }
 
-  // Fetch libraries
-  const { data: libraries, error: librariesError } = await fetchData(`https://openprocessing.org/api/sketch/${parsedId}/libraries?limit=100&offset=0`, `libraries for sketch ${parsedId}`, { quiet });
-  if (librariesError) {
-    setError(librariesError);
+  if (librariesResult.error) {
+    setError(librariesResult.error);
   }
-  if (libraries) {
-    sketchInfo.libraries = libraries;
+  if (librariesResult.data) {
+    sketchInfo.libraries = librariesResult.data;
   }
 
   sketchInfo.metadata = sketchInfo.metadata || {};

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ const opdl = async (sketchId, options = {}) => {
     return result;
   }
 
-  const sketchInfo = await fetchSketchInfo(sketchId, { quiet: mergedOptions.quiet });
+  const sketchInfo = await fetchSketchInfo(sketchId, { quiet: mergedOptions.quiet, token: mergedOptions.token });
 
   if (!sketchInfo) {
     result.sketchInfo.error = 'Invalid sketch ID';


### PR DESCRIPTION
Solves #15 

This PR adds a new `auth` command, enables API token management, and enhances error handling and diagnostics.

When a command runs, the token is resolved in this priority order:

1. `--token` flag (highest)
2. `OP_API_KEY` environment variable
3. `token` in `~/.opdlrc`

The documentation is also updated to reflect these changes.

### Other changes
Switch to the modern OP thumbnail URL (closes #14)