### PR TITLE
Add support for usernames and update registry

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -61,10 +61,10 @@ opdl sketch info 1142958
 opdl 1142958 --info title,license,libraries
 
 # List user's sketches
-opdl user sketches 12345
+opdl user sketches @Sableraph
 
 # Output as JSON
-opdl user 12345 --json
+opdl user @Sableraph --json
 ```
 
 ## Programmatic API
@@ -101,27 +101,26 @@ const { OpenProcessingClient } = require('opdl');
   const client = new OpenProcessingClient();
   // Or with API key: new OpenProcessingClient('your-api-key')
 
+  // --- Block A: sketch + author lookup ---
   // Get sketch details
   const sketch = await client.getSketch(2063664);
   console.log(`${sketch.title} by ${sketch.userID}`);
 
-  // Get user information
-  const user = await client.getUser(sketch.userID);
-  console.log(`Author: ${user.userName}`);
+  // sketch.userID comes from the API response; the @username form is the
+  // preferred way to look up a user when you already have a username.
+  const author = await client.getUser(sketch.userID);
+  console.log(`Author: ${author.fullname}`);
 
-  // Get sketch code
+  // Get sketch code (getSketchCode returns an array directly)
   const code = await client.getSketchCode(2063664);
-  console.log('Files:', code.files.map(f => f.name));
-
-  // List user's sketches with pagination
-  const sketches = await client.getUserSketches(sketch.userID, {
-    limit: 10,
-    offset: 0,
-    sort: 'desc'
-  });
+  console.log('Files:', code.map(f => f.title));
 
   // Get popular tags
   const tags = await client.getTags({ duration: 'thisMonth' });
+
+  // --- Block B: direct user lookup by @username (independent of Block A) ---
+  const user = await client.getUser('@Sableraph');
+  const sketches = await client.getUserSketches('@Sableraph', { limit: 10 });
 })();
 ```
 
@@ -308,31 +307,39 @@ opdl 1142958 --info all --json
 
 Work with OpenProcessing users.
 
+#### User identifiers
+
+OpenProcessing is migrating from numeric `userID` to usernames. Users can be identified by:
+
+- `@username` (preferred, e.g. `@Sableraph`) — note the required `@` prefix
+- numeric `userID` (e.g. `1`) — still accepted but deprecated; `opdl` emits a warning when a numeric userID is used directly
+
 #### Display user information
 
 ```bash
-opdl user <userId> [options]
+opdl user <user> [options]
 ```
 
 **Example:**
 ```bash
-opdl user 1
-opdl user 1 --info fullname,website,createdOn
-opdl user 1 --json
+opdl user @Sableraph
+opdl user @Sableraph --info fullname,website,createdOn
+opdl user @Sableraph --json
+opdl user @Sableraph                # deprecated; prints a warning
 ```
 
 #### List user's sketches
 
 ```bash
-opdl user sketches <userId> [options]
+opdl user sketches <user> [options]
 ```
 
 **Example:**
 ```bash
-opdl user sketches 1
-opdl user sketches 1 --limit 10
-opdl user sketches 1 --info visualID,title,createdOn
-opdl user sketches 1 --json
+opdl user sketches @Sableraph
+opdl user sketches @Sableraph --limit 10
+opdl user sketches @Sableraph --info visualID,title,createdOn
+opdl user sketches @Sableraph --json
 ```
 
 **Note:** The user sketches list endpoint returns limited fields. Use `opdl fields user.sketches` to see available fields. For full sketch details including license and other metadata, fetch each sketch individually with `opdl sketch info <sketchId>`.
@@ -340,26 +347,26 @@ opdl user sketches 1 --json
 #### List user's followers
 
 ```bash
-opdl user followers <userId> [options]
+opdl user followers <user> [options]
 ```
 
 **Example:**
 ```bash
-opdl user followers 1
-opdl user followers 1 --limit 20 --json
-opdl user followers 1 --info userID,fullname
+opdl user followers @Sableraph
+opdl user followers @Sableraph --limit 20 --json
+opdl user followers @Sableraph --info userID,fullname
 ```
 
 #### List users being followed
 
 ```bash
-opdl user following <userId> [options]
+opdl user following <user> [options]
 ```
 
 **Example:**
 ```bash
-opdl user following 1
-opdl user following 1 --limit 20 --json
+opdl user following @Sableraph
+opdl user following @Sableraph --limit 20 --json
 ```
 
 ### Curation Commands
@@ -410,8 +417,8 @@ Select specific fields to display. Can be:
 **Examples:**
 ```bash
 opdl 1142958 --info title,license
-opdl user 1 --info fullname,website,location
-opdl user sketches 1 --info visualID,title,createdOn
+opdl user @Sableraph --info fullname,website,location
+opdl user sketches @Sableraph --info visualID,title,createdOn
 ```
 
 #### `--json`
@@ -421,7 +428,7 @@ Output data in JSON format instead of table format.
 **Examples:**
 ```bash
 opdl sketch info 1142958 --json
-opdl user 1 --json
+opdl user @Sableraph --json
 opdl user sketches 1 --json
 ```
 
@@ -637,19 +644,19 @@ npm run build
 
 ```bash
 # Get user profile
-opdl user 1
+opdl user @Sableraph
 
 # Get specific user fields
-opdl user 1 --info fullname,website,location,createdOn
+opdl user @Sableraph --info fullname,website,location,createdOn
 
 # List user's recent sketches
-opdl user sketches 1 --limit 10 --sort desc
+opdl user sketches @Sableraph --limit 10 --sort desc
 
 # Get sketch IDs and titles only
-opdl user sketches 1 --info visualID,title
+opdl user sketches @Sableraph --info visualID,title
 
 # List first 50 followers as JSON
-opdl user followers 1 --limit 50 --json
+opdl user followers @Sableraph --limit 50 --json
 
 # Check who a user is following
 opdl user following 1 --info userID,fullname,membershipType
@@ -826,13 +833,13 @@ OpenProcessing API key for authenticated requests (if required).
 
 ```bash
 export OP_API_KEY="your-api-key-here"
-opdl user 1
+opdl user @Sableraph
 ```
 
 Or set it for a single command:
 
 ```bash
-OP_API_KEY="your-api-key-here" opdl user 1
+OP_API_KEY="your-api-key-here" opdl user @Sableraph
 ```
 
 ## Exit Codes

--- a/README.md
+++ b/README.md
@@ -141,27 +141,29 @@ const { OpenProcessingClient } = require('opdl');
 (async () => {
   const client = new OpenProcessingClient(process.env.OP_API_KEY);
 
+  // --- Block A: sketch + author lookup ---
   // Get sketch details
   const sketch = await client.getSketch(2063664);
   console.log(`${sketch.title} by userID ${sketch.userID}`);
 
-  // Get user information
-  const user = await client.getUser(sketch.userID);
-  console.log(`Author: ${user.userName}`);
+  // userID is returned by the sketch endpoint; the @username form below
+  // is the preferred form when looking up a known user
+  const author = await client.getUser(sketch.userID);
+  console.log(`Author: ${author.fullname}`);
 
-  // Get sketch code
+  // Get sketch code (getSketchCode returns an array directly)
   const code = await client.getSketchCode(2063664);
-  console.log(`Code files:`, code.files.map(f => f.name));
-
-  // List user's sketches with pagination
-  const userSketches = await client.getUserSketches(sketch.userID, {
-    limit: 10,
-    offset: 0,
-    sort: 'desc'
-  });
+  console.log(`Code files:`, code.map(f => f.title));
 
   // Get popular tags
   const tags = await client.getTags({ duration: 'thisMonth' });
+
+  // --- Block B: direct user lookup by @username (independent of Block A) ---
+  // OpenProcessing is migrating from numeric userIDs to usernames.
+  // When you have a username, prefer the @username form; numeric userIDs
+  // are still accepted but deprecated.
+  const user = await client.getUser('@Sableraph');
+  const sketches = await client.getUserSketches('@Sableraph', { limit: 10 });
 })();
 ```
 

--- a/bin/opdl.js
+++ b/bin/opdl.js
@@ -139,10 +139,11 @@ COMMANDS:
     opdl <sketchId> --info <fields>       Display selected sketch fields
 
   User Commands:
-    opdl user <userId> [options]          Display user information
-    opdl user sketches <userId> [options] List user's sketches
-    opdl user followers <userId> [opts]   List user's followers
-    opdl user following <userId> [opts]   List users being followed
+    Users can be identified by @username (preferred) or numeric userID (deprecated).
+    opdl user <user> [options]            Display user information
+    opdl user sketches <user> [options]   List user's sketches
+    opdl user followers <user> [opts]     List user's followers
+    opdl user following <user> [opts]     List users being followed
 
   Curation Commands:
     opdl curation <id> [options]          Display curation information
@@ -187,9 +188,9 @@ EXAMPLES:
   opdl 1142958 --run
 
   # User operations
-  opdl user 1 --info fullname,website,createdOn
-  opdl user sketches 1 --limit 10 --info visualID,title
-  opdl user followers 1 --json
+  opdl user @Sableraph --info fullname,website,createdOn
+  opdl user sketches @Sableraph --limit 10 --info visualID,title
+  opdl user followers @Sableraph --json
 
   # Curation operations
   opdl curation 12 --info title,description

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -5,7 +5,41 @@
  */
 
 const axios = require('axios');
-const { validateSketch, validateUser, validateCuration } = require('./validator');
+const {
+  validateSketch,
+  validateUser,
+  validateCuration,
+  isStrictPositiveIntegerId,
+  isValidUsernameSegment,
+} = require('./validator');
+
+/**
+ * Format a user path segment for OpenProcessing API URLs.
+ * Accepts positive integer userIDs or @username strings; throws on anything else.
+ * @param {number|string} id
+ * @returns {string}
+ */
+function formatUserPathSegment(id) {
+  if (isStrictPositiveIntegerId(id)) {
+    return String(id);
+  }
+  if (isValidUsernameSegment(id)) {
+    return id;
+  }
+  throw new Error(
+    'User identifier must be a username with "@" prefix (e.g. "@Sableraph") or a positive integer userID. Numeric userIDs are deprecated by OpenProcessing.'
+  );
+}
+
+/**
+ * Throw if a list-endpoint response is an API error envelope ({ success: false, ... }).
+ * @param {*} responseData
+ */
+function ensureNotApiError(responseData) {
+  if (responseData && responseData.success === false) {
+    throw new Error(responseData.message || 'API error');
+  }
+}
 
 /**
  * @typedef {import('../types/api')} API
@@ -143,12 +177,13 @@ class OpenProcessingClient {
 
   /**
    * Get user information
-   * @param {number|string} id - User ID
+   * @param {number|string} id - Username (with @ prefix, e.g. "@Sableraph") or numeric userID (deprecated)
    * @returns {Promise<any>} User data
    * @throws {Error} If user is not found or API returns an error
    */
   async getUser(id) {
-    const response = await this.client.get(`/api/user/${id}`, { validateStatus: () => true });
+    const segment = formatUserPathSegment(id);
+    const response = await this.client.get(`/api/user/${segment}`, { validateStatus: () => true });
     const validation = validateUser(response.data);
 
     if (!validation.valid) {
@@ -160,7 +195,7 @@ class OpenProcessingClient {
 
   /**
    * Get user's sketches
-   * @param {number|string} userId - User ID
+   * @param {number|string} userId - Username (with @ prefix, e.g. "@Sableraph") or numeric userID (deprecated)
    * @param {Object} [options] - List options
    * @param {number} [options.limit] - Maximum number of results
    * @param {number} [options.offset] - Number of results to skip
@@ -168,15 +203,17 @@ class OpenProcessingClient {
    * @returns {Promise<any[]>} User sketches
    */
   async getUserSketches(userId, options = {}) {
-    const response = await this.client.get(`/api/user/${userId}/sketches`, {
+    const segment = formatUserPathSegment(userId);
+    const response = await this.client.get(`/api/user/${segment}/sketches`, {
       params: options,
     });
+    ensureNotApiError(response.data);
     return response.data;
   }
 
   /**
    * Get user's followers
-   * @param {number|string} userId - User ID
+   * @param {number|string} userId - Username (with @ prefix, e.g. "@Sableraph") or numeric userID (deprecated)
    * @param {Object} [options] - List options
    * @param {number} [options.limit] - Maximum number of results
    * @param {number} [options.offset] - Number of results to skip
@@ -184,15 +221,17 @@ class OpenProcessingClient {
    * @returns {Promise<any[]>} User followers
    */
   async getUserFollowers(userId, options = {}) {
-    const response = await this.client.get(`/api/user/${userId}/followers`, {
+    const segment = formatUserPathSegment(userId);
+    const response = await this.client.get(`/api/user/${segment}/followers`, {
       params: options,
     });
+    ensureNotApiError(response.data);
     return response.data;
   }
 
   /**
    * Get users followed by user
-   * @param {number|string} userId - User ID
+   * @param {number|string} userId - Username (with @ prefix, e.g. "@Sableraph") or numeric userID (deprecated)
    * @param {Object} [options] - List options
    * @param {number} [options.limit] - Maximum number of results
    * @param {number} [options.offset] - Number of results to skip
@@ -200,15 +239,17 @@ class OpenProcessingClient {
    * @returns {Promise<any[]>} Users being followed
    */
   async getUserFollowing(userId, options = {}) {
-    const response = await this.client.get(`/api/user/${userId}/following`, {
+    const segment = formatUserPathSegment(userId);
+    const response = await this.client.get(`/api/user/${segment}/following`, {
       params: options,
     });
+    ensureNotApiError(response.data);
     return response.data;
   }
 
   /**
    * Get sketches hearted by user
-   * @param {number|string} userId - User ID
+   * @param {number|string} userId - Username (with @ prefix, e.g. "@Sableraph") or numeric userID (deprecated)
    * @param {Object} [options] - List options
    * @param {number} [options.limit] - Maximum number of results
    * @param {number} [options.offset] - Number of results to skip
@@ -216,9 +257,11 @@ class OpenProcessingClient {
    * @returns {Promise<any[]>} Hearted sketches
    */
   async getUserHearts(userId, options = {}) {
-    const response = await this.client.get(`/api/user/${userId}/hearts`, {
+    const segment = formatUserPathSegment(userId);
+    const response = await this.client.get(`/api/user/${segment}/hearts`, {
       params: options,
     });
+    ensureNotApiError(response.data);
     return response.data;
   }
 

--- a/src/api/validator.js
+++ b/src/api/validator.js
@@ -265,6 +265,66 @@ const validateCuration = (responseData) => {
 };
 
 /**
+ * Strict positive integer check.
+ * Numbers must be integers >= 1. Strings must match /^[1-9]\d*$/ (no leading zeros, no decimals, no exponent).
+ * @param {*} id
+ * @returns {boolean}
+ */
+const isStrictPositiveIntegerId = (id) => {
+  if (typeof id === 'number') {
+    return Number.isInteger(id) && id >= 1;
+  }
+  if (typeof id === 'string') {
+    return /^[1-9]\d*$/.test(id);
+  }
+  return false;
+};
+
+/**
+ * Valid username segment for OpenProcessing API path: must start with a single '@'
+ * followed by at least one non-'@'/non-whitespace character.
+ * @param {*} id
+ * @returns {boolean}
+ */
+const isValidUsernameSegment = (id) => {
+  if (typeof id !== 'string') return false;
+  return /^@[^@\s]+$/.test(id);
+};
+
+/**
+ * Validate a user identifier (either positive integer userID or @username).
+ * @param {*} id
+ * @returns {ValidationResult & { data: { value: number|string, isNumeric: boolean } }}
+ */
+const validateUserIdentifier = (id) => {
+  if (isStrictPositiveIntegerId(id)) {
+    return {
+      valid: true,
+      reason: null,
+      message: '',
+      data: { value: Number(id), isNumeric: true },
+      canRetry: false,
+    };
+  }
+  if (isValidUsernameSegment(id)) {
+    return {
+      valid: true,
+      reason: null,
+      message: '',
+      data: { value: id, isNumeric: false },
+      canRetry: false,
+    };
+  }
+  return {
+    valid: false,
+    reason: VALIDATION_REASONS.INVALID_ID,
+    message: 'User identifier must be a username with "@" prefix (e.g. "@Sableraph") or a positive integer userID.',
+    data: id,
+    canRetry: false,
+  };
+};
+
+/**
  * Validate an ID value
  * ID should be a positive integer
  * @param {*} id - ID to validate
@@ -413,6 +473,9 @@ module.exports = {
   validateUser,
   validateCuration,
   validateId,
+  validateUserIdentifier,
+  isStrictPositiveIntegerId,
+  isValidUsernameSegment,
   validateListOptions,
   validateTagsOptions,
   validateResponse,

--- a/src/cli/commands/user.js
+++ b/src/cli/commands/user.js
@@ -1,8 +1,11 @@
 const { OpenProcessingClient } = require('../../api/client');
 const { selectFields } = require('../fieldSelector');
 const { formatObject, formatArray } = require('../formatters');
-const { validateId } = require('../../api/validator');
+const { validateUserIdentifier } = require('../../api/validator');
 const { getToken } = require('../../config');
+
+const DEPRECATION_WARNING =
+  '\x1b[33m[opdl] Warning: looking up users by numeric userID is deprecated by OpenProcessing and will be removed in the future. Use the @username form instead (e.g. "opdl user @Sableraph"). Run "opdl --help" for command syntax.\x1b[0m';
 
 /**
  * Handle user-related commands
@@ -14,12 +17,16 @@ const { getToken } = require('../../config');
 async function handleUserCommand(args) {
   const client = new OpenProcessingClient(getToken(args.options.token));
 
-  // Validate user ID
-  const idValidation = validateId(args.id);
+  // Validate user identifier (accepts @username or numeric userID)
+  const idValidation = validateUserIdentifier(args.id);
   if (!idValidation.valid) {
     throw new Error(idValidation.message);
   }
-  const userId = idValidation.data;
+  const userId = idValidation.data.value;
+
+  if (idValidation.data.isNumeric && !args.options.quiet) {
+    console.warn(DEPRECATION_WARNING);
+  }
 
   const listOptions = {
     limit: args.options.limit,

--- a/src/cli/fieldRegistry.js
+++ b/src/cli/fieldRegistry.js
@@ -106,8 +106,16 @@ fieldRegistry.register({
     { name: 'userID', description: 'Author user ID', type: 'number' },
     { name: 'parentID', description: 'Parent sketch ID if forked', type: 'number' },
     { name: 'isDraft', description: 'Whether sketch is a draft (0=false, 1=true)', type: 'number' },
+    { name: 'isPrivate', description: 'Whether sketch is private (0=false, 1=true)', type: 'number' },
     { name: 'isTemplate', description: 'Whether sketch is a template (0=false, 1=true)', type: 'number' },
     { name: 'tutorialMode', description: 'Whether sketch is a tutorial (0=false, 1=true)', type: 'number' },
+    { name: 'username', description: 'Author username (preferred over userID)', type: 'string' },
+    { name: 'engineID', description: 'Rendering engine ID', type: 'number' },
+    { name: 'engineURL', description: 'Rendering engine URL', type: 'string' },
+    { name: 'fileBase', description: 'Base path for sketch files', type: 'string' },
+    { name: 'filesUpdatedOn', description: 'Date files were last updated', type: 'date' },
+    { name: 'thumbnailUpdatedOn', description: 'Date thumbnail was last updated', type: 'date' },
+    { name: 'videoUpdatedOn', description: 'Date video was last updated (null if no video)', type: 'date' },
   ],
 });
 
@@ -117,12 +125,15 @@ fieldRegistry.register({
   description: 'Fields available for user objects',
   endpoint: '/api/user/:id',
   fields: [
-    { name: 'userID', description: 'User ID', type: 'number' },
+    { name: 'userID', description: 'User ID (deprecated; prefer username)', type: 'number' },
+    { name: 'username', description: 'Username (preferred identifier)', type: 'string' },
     { name: 'fullname', description: 'Full name', type: 'string' },
     { name: 'website', description: 'Website URL', type: 'string' },
     { name: 'location', description: 'Location', type: 'string' },
     { name: 'bio', description: 'User biography', type: 'string' },
     { name: 'createdOn', description: 'Account creation date', type: 'date' },
+    { name: 'membershipType', description: 'Membership type (enum: 0=free, 1=plus, 2=pro, 3=educator)', type: 'number' },
+    { name: 'totalSketches', description: 'Total number of sketches', type: 'number' },
   ],
 });
 
@@ -136,7 +147,8 @@ fieldRegistry.register({
     { name: 'title', description: 'Curation title', type: 'string' },
     { name: 'description', description: 'Curation description', type: 'string' },
     { name: 'createdOn', description: 'Creation date', type: 'date' },
-    { name: 'userID', description: 'Creator user ID', type: 'number' },
+    { name: 'userID', description: 'Creator user ID (deprecated; prefer username)', type: 'number' },
+    { name: 'username', description: 'Creator username (preferred identifier)', type: 'string' },
   ],
 });
 
@@ -151,7 +163,13 @@ fieldRegistry.register({
     { name: 'description', description: 'Sketch description', type: 'string' },
     { name: 'instructions', description: 'Usage instructions', type: 'string' },
     { name: 'createdOn', description: 'Creation date', type: 'date' },
+    { name: 'updatedOn', description: 'Last modification date', type: 'date' },
     { name: 'mode', description: 'Sketch mode (p5js, processingjs, html, applet)', type: 'string' },
+    { name: 'userID', description: 'Author user ID (deprecated; prefer username)', type: 'number' },
+    { name: 'username', description: 'Author username (preferred identifier)', type: 'string' },
+    { name: 'fullname', description: 'Author full name', type: 'string' },
+    { name: 'isDraft', description: 'Whether sketch is a draft (0=false, 1=true)', type: 'number' },
+    { name: 'isPrivate', description: 'Whether sketch is private (0=false, 1=true)', type: 'number' },
   ],
 });
 
@@ -161,10 +179,11 @@ fieldRegistry.register({
   description: 'Fields available for user followers list',
   endpoint: '/api/user/:id/followers',
   fields: [
-    { name: 'userID', description: 'User ID', type: 'number' },
+    { name: 'userID', description: 'User ID (deprecated; prefer username)', type: 'number' },
+    { name: 'username', description: 'Username (preferred identifier)', type: 'string' },
     { name: 'fullname', description: 'Full name', type: 'string' },
     { name: 'followedOn', description: 'Date when follow occurred', type: 'date' },
-    { name: 'membershipType', description: 'Membership type (enum: 0=free, 1=supporter, 2=patron, 3=unknown)', type: 'number' },
+    { name: 'membershipType', description: 'Membership type (enum: 0=free, 1=plus, 2=pro, 3=educator)', type: 'number' },
   ],
 });
 
@@ -174,10 +193,11 @@ fieldRegistry.register({
   description: 'Fields available for user following list',
   endpoint: '/api/user/:id/following',
   fields: [
-    { name: 'userID', description: 'User ID', type: 'number' },
+    { name: 'userID', description: 'User ID (deprecated; prefer username)', type: 'number' },
+    { name: 'username', description: 'Username (preferred identifier)', type: 'string' },
     { name: 'fullname', description: 'Full name', type: 'string' },
     { name: 'followedOn', description: 'Date when follow occurred', type: 'date' },
-    { name: 'membershipType', description: 'Membership type (enum: 0=free, 1=supporter, 2=patron, 3=unknown)', type: 'number' },
+    { name: 'membershipType', description: 'Membership type (enum: 0=free, 1=plus, 2=pro, 3=educator)', type: 'number' },
   ],
 });
 
@@ -197,9 +217,10 @@ fieldRegistry.register({
     { name: 'submittedOn', description: 'Submission date', type: 'date' },
     { name: 'thumbnailUpdatedOn', description: 'Thumbnail update date', type: 'date' },
     { name: 'videoUpdatedOn', description: 'Video update date (null if no video)', type: 'date' },
-    { name: 'userID', description: 'Author user ID', type: 'number' },
+    { name: 'userID', description: 'Author user ID (deprecated; prefer username)', type: 'number' },
+    { name: 'username', description: 'Author username (preferred identifier)', type: 'string' },
     { name: 'fullname', description: 'Author full name', type: 'string' },
-    { name: 'membershipType', description: 'Author membership type (enum: 0=free, 1=supporter, 2=patron, 3=unknown)', type: 'number' },
+    { name: 'membershipType', description: 'Author membership type (enum: 0=free, 1=plus, 2=pro, 3=educator)', type: 'number' },
     { name: 'status', description: 'Sketch status (0=hidden/draft, 1=published/visible)', type: 'number' },
   ],
 });

--- a/tests/api/client.test.mjs
+++ b/tests/api/client.test.mjs
@@ -194,13 +194,20 @@ describe('OpenProcessingClient', () => {
       assert.deepEqual(result, mockFollowers);
     });
 
-    it('should handle fullname instead of ID', async () => {
+    it('should accept @username and hit the /@username path', async () => {
       nock(BASE_URL)
-        .get('/api/user/testuser/followers')
+        .get('/api/user/@testuser/followers')
         .reply(200, []);
 
-      const result = await client.getUserFollowers('testuser');
+      const result = await client.getUserFollowers('@testuser');
       assert.deepEqual(result, []);
+    });
+
+    it('should reject bare non-numeric identifiers (no @ prefix) without making a request', async () => {
+      await assert.rejects(
+        async () => await client.getUserFollowers('testuser'),
+        { message: /username|deprecated/ }
+      );
     });
 
     it('should pass list options', async () => {
@@ -474,6 +481,77 @@ describe('OpenProcessingClient', () => {
         .reply(404, { message: 'Not found' });
 
       await assert.rejects(async () => await client.getUserHearts(456));
+    });
+  });
+
+  describe('User identifier handling', () => {
+    it('getUser hits /api/user/@username for @username', async () => {
+      nock(BASE_URL)
+        .get('/api/user/@Sableraph')
+        .reply(200, { userID: 1, fullname: 'Test' });
+
+      const result = await client.getUser('@Sableraph');
+      assert.equal(result.fullname, 'Test');
+    });
+
+    it('getUser still works with numeric IDs', async () => {
+      nock(BASE_URL)
+        .get('/api/user/123')
+        .reply(200, { userID: 123, fullname: 'Test' });
+
+      const result = await client.getUser(123);
+      assert.equal(result.userID, 123);
+    });
+
+    it('getUser rejects bare non-numeric input synchronously', async () => {
+      await assert.rejects(async () => await client.getUser('Sableraph'), { message: /username|deprecated/ });
+    });
+
+    it('getUser rejects 0, negatives, leading zeros, decimals, exponent-strings', async () => {
+      for (const bad of [0, -1, '01', '1.5', '1e3']) {
+        await assert.rejects(
+          async () => await client.getUser(bad),
+          { message: /username|deprecated/ },
+          `should reject ${JSON.stringify(bad)}`
+        );
+      }
+    });
+  });
+
+  describe('List endpoint error envelope handling', () => {
+    it('getUserSketches throws on { success: false } envelope', async () => {
+      nock(BASE_URL)
+        .get('/api/user/@ghost/sketches')
+        .reply(200, { success: false, message: 'User not found.' });
+
+      await assert.rejects(
+        async () => await client.getUserSketches('@ghost'),
+        { message: /User not found/ }
+      );
+    });
+
+    it('getUserFollowers throws on { success: false }', async () => {
+      nock(BASE_URL)
+        .get('/api/user/@ghost/followers')
+        .reply(200, { success: false, message: 'User not found.' });
+
+      await assert.rejects(async () => await client.getUserFollowers('@ghost'), { message: /User not found/ });
+    });
+
+    it('getUserFollowing throws on { success: false }', async () => {
+      nock(BASE_URL)
+        .get('/api/user/@ghost/following')
+        .reply(200, { success: false, message: 'User not found.' });
+
+      await assert.rejects(async () => await client.getUserFollowing('@ghost'), { message: /User not found/ });
+    });
+
+    it('getUserHearts throws on { success: false }', async () => {
+      nock(BASE_URL)
+        .get('/api/user/@ghost/hearts')
+        .reply(200, { success: false, message: 'User not found.' });
+
+      await assert.rejects(async () => await client.getUserHearts('@ghost'), { message: /User not found/ });
     });
   });
 

--- a/tests/api/validator.test.mjs
+++ b/tests/api/validator.test.mjs
@@ -5,6 +5,9 @@ import {
   validateUser,
   validateCuration,
   validateId,
+  validateUserIdentifier,
+  isStrictPositiveIntegerId,
+  isValidUsernameSegment,
   validateListOptions,
   validateTagsOptions,
   validateResponse,
@@ -389,6 +392,116 @@ describe('Validator Module', () => {
       const result = validateId(Infinity);
       assert.equal(result.valid, false);
       assert.equal(result.reason, VALIDATION_REASONS.INVALID_ID);
+    });
+  });
+
+  describe('isStrictPositiveIntegerId', () => {
+    it('accepts positive integers (number)', () => {
+      assert.equal(isStrictPositiveIntegerId(1), true);
+      assert.equal(isStrictPositiveIntegerId(1000), true);
+      assert.equal(isStrictPositiveIntegerId(1e3), true); // 1000 at runtime
+    });
+
+    it('rejects non-positive or non-integer numbers', () => {
+      assert.equal(isStrictPositiveIntegerId(0), false);
+      assert.equal(isStrictPositiveIntegerId(-1), false);
+      assert.equal(isStrictPositiveIntegerId(1.5), false);
+      assert.equal(isStrictPositiveIntegerId(NaN), false);
+      assert.equal(isStrictPositiveIntegerId(Infinity), false);
+    });
+
+    it('accepts strict positive integer strings', () => {
+      assert.equal(isStrictPositiveIntegerId('1'), true);
+      assert.equal(isStrictPositiveIntegerId('123'), true);
+    });
+
+    it('rejects malformed strings', () => {
+      assert.equal(isStrictPositiveIntegerId('0'), false);
+      assert.equal(isStrictPositiveIntegerId('01'), false);
+      assert.equal(isStrictPositiveIntegerId('1.5'), false);
+      assert.equal(isStrictPositiveIntegerId('1e3'), false);
+      assert.equal(isStrictPositiveIntegerId(''), false);
+      assert.equal(isStrictPositiveIntegerId(' 1'), false);
+      assert.equal(isStrictPositiveIntegerId('+1'), false);
+      assert.equal(isStrictPositiveIntegerId('-1'), false);
+    });
+
+    it('rejects other types', () => {
+      assert.equal(isStrictPositiveIntegerId(null), false);
+      assert.equal(isStrictPositiveIntegerId(undefined), false);
+      assert.equal(isStrictPositiveIntegerId({}), false);
+    });
+  });
+
+  describe('isValidUsernameSegment', () => {
+    it('accepts @-prefixed usernames', () => {
+      assert.equal(isValidUsernameSegment('@Sableraph'), true);
+      assert.equal(isValidUsernameSegment('@a'), true);
+      assert.equal(isValidUsernameSegment('@foo_bar-1'), true);
+    });
+
+    it('rejects strings without @ or malformed', () => {
+      assert.equal(isValidUsernameSegment('Sableraph'), false);
+      assert.equal(isValidUsernameSegment('@'), false);
+      assert.equal(isValidUsernameSegment('@@'), false);
+      assert.equal(isValidUsernameSegment('@@foo'), false);
+      assert.equal(isValidUsernameSegment('@ '), false);
+      assert.equal(isValidUsernameSegment('@foo bar'), false);
+      assert.equal(isValidUsernameSegment(''), false);
+    });
+
+    it('rejects non-strings', () => {
+      assert.equal(isValidUsernameSegment(1), false);
+      assert.equal(isValidUsernameSegment(null), false);
+      assert.equal(isValidUsernameSegment(undefined), false);
+    });
+  });
+
+  describe('validateUserIdentifier', () => {
+    it('accepts positive integer (number)', () => {
+      const r = validateUserIdentifier(1);
+      assert.equal(r.valid, true);
+      assert.equal(r.data.value, 1);
+      assert.equal(r.data.isNumeric, true);
+    });
+
+    it('accepts positive integer string', () => {
+      const r = validateUserIdentifier('123');
+      assert.equal(r.valid, true);
+      assert.equal(r.data.value, 123);
+      assert.equal(r.data.isNumeric, true);
+    });
+
+    it('accepts @username', () => {
+      const r = validateUserIdentifier('@Sableraph');
+      assert.equal(r.valid, true);
+      assert.equal(r.data.value, '@Sableraph');
+      assert.equal(r.data.isNumeric, false);
+    });
+
+    it('rejects bare non-numeric strings', () => {
+      const r = validateUserIdentifier('Sableraph');
+      assert.equal(r.valid, false);
+      assert.match(r.message, /@username|@ prefix|@"/);
+    });
+
+    it('rejects malformed @ strings', () => {
+      for (const v of ['@', '@@', '@@foo', '@ foo', '@foo bar']) {
+        assert.equal(validateUserIdentifier(v).valid, false, `should reject ${JSON.stringify(v)}`);
+      }
+    });
+
+    it('rejects non-strict numeric inputs', () => {
+      for (const v of ['', '0', '-1', '01', '1.5', '1e3', 0, -1, 1.5, NaN, Infinity, null, undefined]) {
+        assert.equal(validateUserIdentifier(v).valid, false, `should reject ${JSON.stringify(v)}`);
+      }
+    });
+
+    it('1e3 as a number is valid (already 1000 at runtime)', () => {
+      const r = validateUserIdentifier(1e3);
+      assert.equal(r.valid, true);
+      assert.equal(r.data.value, 1000);
+      assert.equal(r.data.isNumeric, true);
     });
   });
 

--- a/tests/cli/cli.test.mjs
+++ b/tests/cli/cli.test.mjs
@@ -119,6 +119,30 @@ describe('CLI Parser', () => {
         expect(result.options.offset).toBe(5);
         expect(result.options.sort).toBe('desc');
       });
+
+      it('should parse user info command with @username', () => {
+        const result = parseArgs(['user', '@Sableraph']);
+        expect(result).toEqual({
+          command: 'user',
+          subcommand: null,
+          id: '@Sableraph',
+          options: {}
+        });
+      });
+
+      it('should parse user sketches with @username', () => {
+        const result = parseArgs(['user', 'sketches', '@Sableraph']);
+        expect(result.command).toBe('user');
+        expect(result.subcommand).toBe('sketches');
+        expect(result.id).toBe('@Sableraph');
+      });
+
+      it('should parse user followers with @username and --limit', () => {
+        const result = parseArgs(['user', 'followers', '@Sableraph', '--limit', '5']);
+        expect(result.subcommand).toBe('followers');
+        expect(result.id).toBe('@Sableraph');
+        expect(result.options.limit).toBe(5);
+      });
     });
 
     describe('curation command', () => {

--- a/tests/cli/commands/user.test.mjs
+++ b/tests/cli/commands/user.test.mjs
@@ -1,0 +1,65 @@
+import { describe, it, beforeEach, afterEach, vi, expect } from 'vitest';
+import nock from 'nock';
+import { handleUserCommand } from '../../../src/cli/commands/user.js';
+
+const BASE_URL = 'https://openprocessing.org';
+
+describe('handleUserCommand - deprecation warning', () => {
+  let warnSpy;
+
+  beforeEach(() => {
+    if (console._orig && console._orig.warn) {
+      console.warn = console._orig.warn;
+    }
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    vi.stubEnv('OP_API_KEY', 'test-token');
+    nock.cleanAll();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    nock.cleanAll();
+  });
+
+  it('warns when numeric id is used', async () => {
+    nock(BASE_URL).get('/api/user/1').reply(200, { userID: 1, fullname: 'Test' });
+    await handleUserCommand({ id: '1', subcommand: null, options: {} });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/deprecated/);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/@username|@Sableraph/);
+  });
+
+  it('does not warn when --quiet is set with numeric id', async () => {
+    nock(BASE_URL).get('/api/user/1').reply(200, { userID: 1, fullname: 'Test' });
+    await handleUserCommand({ id: '1', subcommand: null, options: { quiet: true } });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not warn for @username', async () => {
+    nock(BASE_URL).get('/api/user/@Sableraph').reply(200, { userID: 1, fullname: 'Test' });
+    await handleUserCommand({ id: '@Sableraph', subcommand: null, options: {} });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns on numeric id for subcommand sketches', async () => {
+    nock(BASE_URL).get('/api/user/1/sketches').query(true).reply(200, []);
+    await handleUserCommand({ id: '1', subcommand: 'sketches', options: {} });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/deprecated/);
+  });
+
+  it('warns on numeric id for subcommand followers', async () => {
+    nock(BASE_URL).get('/api/user/1/followers').query(true).reply(200, []);
+    await handleUserCommand({ id: '1', subcommand: 'followers', options: {} });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns on numeric id for subcommand following', async () => {
+    nock(BASE_URL).get('/api/user/1/following').query(true).reply(200, []);
+    await handleUserCommand({ id: '1', subcommand: 'following', options: {} });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Accept `@username` as a user identifier across the CLI and API client; numeric userIDs still work but emit a deprecation warning (suppressed by `--quiet`).

Tighten client-side validation: bare non-numeric input is rejected with a helpful message, and the four user list endpoints (sketches/followers/following/hearts) now surface `{success:false}` responses instead of crashing the formatter.

Update help text, `README`, and `HELP.md` examples to prefer `@username`.

Update the registry with missing fields.

Fix #19