### PR TITLE
Add default stylesheet generation and tests

### DIFF
--- a/src/download/htmlGenerator.js
+++ b/src/download/htmlGenerator.js
@@ -1,7 +1,24 @@
 const fs = require('fs');
 const path = require('path');
 
+const DEFAULT_STYLESHEET = `body {
+  padding: 0;
+  margin: 0;
+}
+`;
+
 const generateIndexHtml = (metadata, codeParts, outputDir) => {
+  const parts = codeParts || [];
+  const hasExistingHtml = parts.some((part) => part.title === 'index.html');
+
+  if (hasExistingHtml) {
+    return;
+  }
+
+  const hasExistingCss = parts.some(
+    (part) => part.title && part.title.toLowerCase().endsWith('.css')
+  );
+
   let engineURL = metadata.engineURL ? metadata.engineURL.replace(/\\/g, '') : '';
 
   if (engineURL.startsWith('/')) {
@@ -23,25 +40,29 @@ const generateIndexHtml = (metadata, codeParts, outputDir) => {
     .join('\n    ');
   const librariesSection = libraries ? `    ${libraries}\n` : '';
 
-  const scriptTags = (codeParts || [])
+  const scriptTags = parts
     .filter((part) => part.title && part.title.endsWith('.js'))
     .map((part) => `<script src="${part.title}"></script>`)
     .join('\n    ');
   const scriptTagsSection = scriptTags ? `    ${scriptTags}\n` : '';
 
-  const scriptTagsDefault = (codeParts || [])
+  const scriptTagsDefault = parts
     .filter((part) => part.title && !part.title.includes('.'))
     .map((part) => `<script src="${part.title}.js"></script>`)
     .join('\n    ');
   const scriptTagsDefaultSection = scriptTagsDefault ? `    ${scriptTagsDefault}\n` : '';
 
-  const cssLinkTags = (codeParts || [])
+  const cssLinkTags = parts
     .filter((part) => part.title && part.title.endsWith('.css'))
     .map((part) => `<link rel="stylesheet" type="text/css" href="${part.title}">`)
     .join('\n    ');
   const cssLinkTagsSection = cssLinkTags ? `    ${cssLinkTags}\n` : '';
 
-  const htmlContent = `${htmlHeadStart}${librariesSection}${scriptTagsSection}${scriptTagsDefaultSection}${cssLinkTagsSection}</head>
+  const defaultCssLinkSection = hasExistingCss
+    ? ''
+    : `    <link rel="stylesheet" type="text/css" href="style.css">\n`;
+
+  const htmlContent = `${htmlHeadStart}${librariesSection}${scriptTagsSection}${scriptTagsDefaultSection}${cssLinkTagsSection}${defaultCssLinkSection}</head>
 
 <body>
 
@@ -55,6 +76,11 @@ const generateIndexHtml = (metadata, codeParts, outputDir) => {
 
   const outputPath = path.join(outputDir, 'index.html');
   fs.writeFileSync(outputPath, htmlContent, 'utf8');
+
+  if (!hasExistingCss) {
+    const stylesheetPath = path.join(outputDir, 'style.css');
+    fs.writeFileSync(stylesheetPath, DEFAULT_STYLESHEET, 'utf8');
+  }
 };
 
-module.exports = { generateIndexHtml };
+module.exports = { generateIndexHtml, DEFAULT_STYLESHEET };

--- a/tests/download/downloader.test.mjs
+++ b/tests/download/downloader.test.mjs
@@ -342,6 +342,100 @@ describe('downloader', () => {
 
       const indexFiles = fs.readdirSync(testDir).filter(f => f === 'index.html');
       expect(indexFiles.length).toBe(1);
+      expect(fs.existsSync(path.join(testDir, 'style.css'))).toBe(false);
+    });
+
+    it('should not overwrite an existing index.html code part for non-html mode', async () => {
+      const originalHtml = '<html><body>user index</body></html>';
+      const sketchInfo = {
+        sketchId: 12345,
+        title: 'Test',
+        author: 'Author',
+        codeParts: [
+          { title: 'index.html', code: originalHtml },
+        ],
+        files: [],
+        metadata: {
+          mode: 'p5js',
+          engineURL: 'https://example.com/p5.js',
+        },
+      };
+
+      await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: false,
+      });
+
+      const content = fs.readFileSync(path.join(testDir, 'index.html'), 'utf8');
+      expect(content).toBe(originalHtml);
+      expect(fs.existsSync(path.join(testDir, 'style.css'))).toBe(false);
+    });
+
+    it('should not write default style.css when a user CSS code part exists', async () => {
+      const sketchInfo = {
+        sketchId: 12345,
+        title: 'Test',
+        author: 'Author',
+        codeParts: [
+          { title: 'sketch.js', code: 'test' },
+          { title: 'theme.css', code: 'body { color: red; }' },
+        ],
+        files: [],
+        metadata: {
+          mode: 'p5js',
+          engineURL: 'https://example.com/p5.js',
+        },
+      };
+
+      await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: false,
+      });
+
+      expect(fs.existsSync(path.join(testDir, 'index.html'))).toBe(true);
+      const themeContent = fs.readFileSync(path.join(testDir, 'theme.css'), 'utf8');
+      expect(themeContent).toBe('body { color: red; }');
+      const html = fs.readFileSync(path.join(testDir, 'index.html'), 'utf8');
+      expect(html).toContain('href="theme.css"');
+      expect(html).not.toContain('href="style.css"');
+    });
+
+    it('should write default style.css for non-html mode sketches', async () => {
+      const sketchInfo = {
+        sketchId: 12345,
+        title: 'Test',
+        author: 'Author',
+        codeParts: [
+          { title: 'sketch.js', code: 'test' },
+        ],
+        files: [],
+        metadata: {
+          mode: 'p5js',
+          engineURL: 'https://example.com/p5.js',
+        },
+      };
+
+      await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: false,
+      });
+
+      expect(fs.existsSync(path.join(testDir, 'style.css'))).toBe(true);
     });
 
     it('should create LICENSE file when enabled', async () => {

--- a/tests/download/htmlGenerator.test.mjs
+++ b/tests/download/htmlGenerator.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
-import { generateIndexHtml } from '../../src/download/htmlGenerator';
+import { generateIndexHtml, DEFAULT_STYLESHEET } from '../../src/download/htmlGenerator';
 
 describe('htmlGenerator', () => {
   const testDir = path.join(__dirname, 'test-html-output');
@@ -203,6 +203,79 @@ describe('htmlGenerator', () => {
       expect(content).toMatch(/<\/body>/);
       expect(content).toMatch(/<\/html>/);
       expect(content).toContain('<meta charset="utf-8"');
+    });
+
+    it('should write default style.css to outputDir', () => {
+      const metadata = {
+        engineURL: 'https://example.com/engine.js',
+      };
+
+      generateIndexHtml(metadata, [], testDir);
+
+      const cssPath = path.join(testDir, 'style.css');
+      expect(fs.existsSync(cssPath)).toBe(true);
+
+      const css = fs.readFileSync(cssPath, 'utf8');
+      expect(css).toBe(DEFAULT_STYLESHEET);
+      expect(css).toContain('body {');
+      expect(css).toContain('margin: 0;');
+      expect(css).toContain('padding: 0;');
+    });
+
+    it('should link default style.css from generated index.html', () => {
+      const metadata = {
+        engineURL: 'https://example.com/engine.js',
+      };
+
+      generateIndexHtml(metadata, [], testDir);
+      const content = fs.readFileSync(path.join(testDir, 'index.html'), 'utf8');
+
+      expect(content).toContain('<link rel="stylesheet" type="text/css" href="style.css">');
+    });
+
+    it('should not inject default stylesheet when any user CSS exists', () => {
+      const metadata = {
+        engineURL: 'https://example.com/engine.js',
+      };
+      const codeParts = [
+        { title: 'theme.css' },
+      ];
+
+      generateIndexHtml(metadata, codeParts, testDir);
+      const content = fs.readFileSync(path.join(testDir, 'index.html'), 'utf8');
+
+      expect(content).toContain('<link rel="stylesheet" type="text/css" href="theme.css">');
+      expect(content).not.toContain('href="style.css"');
+      expect(fs.existsSync(path.join(testDir, 'style.css'))).toBe(false);
+    });
+
+    it('should not inject default stylesheet when a style.css code part exists', () => {
+      const metadata = {
+        engineURL: 'https://example.com/engine.js',
+      };
+      const codeParts = [
+        { title: 'style.css' },
+      ];
+
+      generateIndexHtml(metadata, codeParts, testDir);
+      const content = fs.readFileSync(path.join(testDir, 'index.html'), 'utf8');
+
+      const matches = content.match(/href="style\.css"/g) || [];
+      expect(matches.length).toBe(1);
+    });
+
+    it('should not write index.html or default style.css when codeParts contains index.html', () => {
+      const metadata = {
+        engineURL: 'https://example.com/engine.js',
+      };
+      const codeParts = [
+        { title: 'index.html' },
+      ];
+
+      generateIndexHtml(metadata, codeParts, testDir);
+
+      expect(fs.existsSync(path.join(testDir, 'index.html'))).toBe(false);
+      expect(fs.existsSync(path.join(testDir, 'style.css'))).toBe(false);
     });
 
     it('should filter out code parts without titles', () => {


### PR DESCRIPTION
Introduce a default stylesheet and have generateIndexHtml write a style.css into the outputDir and include a <link> to it in the generated index.html for projects that don't use the html mode.

Avoid overwriting user HTML/CSS when they exist.

Fix #21 