### PR TITLE
 support tutorials

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -112,6 +112,33 @@ class OpenProcessingClient {
   }
 
   /**
+   * Get tutorial index for a sketch.
+   * Omits `validateStatus: () => true` so 4xx/5xx (including 429) throw via
+   * the response interceptor.
+   *
+   * @param {number} id - Sketch (visual) ID
+   * @returns {Promise<any>} Tutorial index payload (incl. totalPages, tutorialMode)
+   */
+  async getTutorial(id) {
+    const response = await this.client.get(`/api/tutorial/${id}`);
+    ensureNotApiError(response.data);
+    return response.data;
+  }
+
+  /**
+   * Get a single tutorial page.
+   *
+   * @param {number} id - Sketch (visual) ID
+   * @param {number} pageNumber - 1-based page index
+   * @returns {Promise<any>} Tutorial page payload (markdown, codeObjects, ...)
+   */
+  async getTutorialPage(id, pageNumber) {
+    const response = await this.client.get(`/api/tutorial/${id}/page/${pageNumber}/`);
+    ensureNotApiError(response.data);
+    return response.data;
+  }
+
+  /**
    * Get sketch files/assets
    * @param {number} id - Sketch ID
    * @param {Object} [options] - List options

--- a/src/api/types.js
+++ b/src/api/types.js
@@ -23,7 +23,7 @@
  * @property {number} engineID - Processing engine version ID
  * @property {string} engineURL - CDN URL for the selected p5.js/processing.js engine
  * @property {string} fileBase - S3 base URL for sketch assets
- * @property {number} tutorialMode - Tutorial flag (0 = not tutorial, 1 = tutorial)
+ * @property {number|string} tutorialMode - Tutorial flag. /api/sketch returns 0|1; /api/tutorial returns "normal"|"singleCode"
  * @property {number} isTemplate - Template flag (0 = not template, 1 = template)
  * @property {number} hasTimeline - Timeline feature flag (0 = no timeline, 1 = has timeline)
  * @property {number} userID - ID of sketch creator
@@ -171,6 +171,20 @@
  * @property {number} [limit] - Maximum results (1-100, default 20)
  * @property {number} [offset] - Number of results to skip (>=0, default 0)
  * @property {'thisWeek'|'thisMonth'|'thisYear'|'anytime'} [duration] - Time period (default "anytime")
+ */
+
+/**
+ * @typedef {Object} TutorialPage
+ * @property {number} pageNumber - 1-based page index
+ * @property {string} markdown - Page markdown body (empty string if missing)
+ * @property {Array} codeObjects - Per-page code files ({ title, code, ... }); empty in singleCode mode
+ */
+
+/**
+ * @typedef {Object} TutorialBundle
+ * @property {Object} tutorial - Raw /api/tutorial/{id} payload (includes totalPages, tutorialMode)
+ * @property {TutorialPage[]} pages - Successfully fetched pages
+ * @property {Array<{pageNumber: number, error: Error}>} failedPages - Pages that failed all retries
  */
 
 /**

--- a/src/cli/fieldRegistry.js
+++ b/src/cli/fieldRegistry.js
@@ -108,7 +108,7 @@ fieldRegistry.register({
     { name: 'isDraft', description: 'Whether sketch is a draft (0=false, 1=true)', type: 'number' },
     { name: 'isPrivate', description: 'Whether sketch is private (0=false, 1=true)', type: 'number' },
     { name: 'isTemplate', description: 'Whether sketch is a template (0=false, 1=true)', type: 'number' },
-    { name: 'tutorialMode', description: 'Whether sketch is a tutorial (0=false, 1=true)', type: 'number' },
+    { name: 'tutorialMode', description: 'Tutorial flag (0/1 from /api/sketch; "normal" or "singleCode" from /api/tutorial)', type: 'string' },
     { name: 'username', description: 'Author username (preferred over userID)', type: 'string' },
     { name: 'engineID', description: 'Rendering engine ID', type: 'number' },
     { name: 'engineURL', description: 'Rendering engine URL', type: 'string' },

--- a/src/download/codeFileWriter.js
+++ b/src/download/codeFileWriter.js
@@ -1,0 +1,75 @@
+const fs = require('fs');
+const path = require('path');
+
+const { sanitizeFilename } = require('../utils');
+const { buildCommentBlock } = require('./codeAttributor');
+
+/**
+ * Write a single code block to disk, deduplicating filename collisions inside outputDir.
+ *
+ * @param {Object} params
+ * @param {string} params.outputDir - Destination directory (must already exist).
+ * @param {Object} params.codeBlock - { title, code } from the API.
+ * @param {number} params.index - Zero-based index for fallback naming.
+ * @param {Object} params.sketchInfo - Used by buildCommentBlock for attribution.
+ * @param {boolean} params.addSourceComments - Whether to prepend the attribution block.
+ * @param {string} [params.fallbackBase='part'] - Base name when title is missing.
+ * @param {Set<string>} params.usedNames - Caller-owned Set; mutated to track collisions.
+ * @returns {{ codeFilePath: string, sanitizedCodeBlock: Object, codeFileName: string }}
+ */
+function writeCodeFile({
+  outputDir,
+  codeBlock,
+  index,
+  sketchInfo,
+  addSourceComments,
+  fallbackBase = 'part',
+  usedNames,
+}) {
+  if (!usedNames || typeof usedNames.has !== 'function') {
+    throw new Error('writeCodeFile: usedNames Set is required');
+  }
+
+  const name = codeBlock.title || `${fallbackBase}_${index + 1}`;
+  let codeFileName = path.basename(name);
+  let fileExtension = path.extname(codeFileName);
+
+  if (!fileExtension) {
+    fileExtension = '.js';
+    codeFileName += fileExtension;
+  }
+
+  codeFileName = sanitizeFilename(codeFileName) || `${fallbackBase}_${index + 1}.js`;
+  // Recompute the extension after sanitization (in case sanitize stripped it).
+  fileExtension = path.extname(codeFileName) || '.js';
+
+  // De-dup within outputDir.
+  if (usedNames.has(codeFileName)) {
+    const ext = path.extname(codeFileName);
+    const base = codeFileName.slice(0, codeFileName.length - ext.length);
+    let suffix = 2;
+    let candidate = `${base}_${suffix}${ext}`;
+    while (usedNames.has(candidate)) {
+      suffix += 1;
+      candidate = `${base}_${suffix}${ext}`;
+    }
+    codeFileName = candidate;
+  }
+  usedNames.add(codeFileName);
+
+  const codeFilePath = path.join(outputDir, codeFileName);
+  let fileContent = codeBlock.code || '';
+  if (addSourceComments && !fileContent.includes('Downloaded with opdl')) {
+    const commentBlock = buildCommentBlock(sketchInfo, fileExtension);
+    fileContent = `${commentBlock}${fileContent.startsWith('\n') ? '' : '\n'}${fileContent}`;
+  }
+  fs.writeFileSync(codeFilePath, fileContent, 'utf8');
+
+  return {
+    codeFilePath,
+    codeFileName,
+    sanitizedCodeBlock: { ...codeBlock, title: codeFileName },
+  };
+}
+
+module.exports = { writeCodeFile };

--- a/src/download/downloader.js
+++ b/src/download/downloader.js
@@ -4,9 +4,10 @@ const axios = require('axios');
 
 const { ensureDirectoryExists, sanitizeFilename, resolveAssetUrl } = require('../utils');
 const { generateIndexHtml } = require('./htmlGenerator');
-const { buildCommentBlock } = require('./codeAttributor');
 const { createLicenseFile } = require('./licenseHandler');
 const { createOpMetadata } = require('./metadataWriter');
+const { writeCodeFile } = require('./codeFileWriter');
+const { writeTutorial } = require('./tutorialWriter');
 
 const META_DIR = 'metadata';
 const THUMBNAIL_URL_TEMPLATE = 'https://kyoko.openprocessing.org/thumbnails/visualThumbnail{visualID}@2x.jpg';
@@ -24,29 +25,20 @@ const downloadSketch = async (sketchInfo, options = {}) => {
   const savedCodeFiles = [];
   const sanitizedCodeParts = [];
   const codeParts = Array.isArray(sketchInfo.codeParts) ? sketchInfo.codeParts : [];
+  const rootUsedNames = new Set();
 
   for (let index = 0; index < codeParts.length; index += 1) {
-    const codeBlock = codeParts[index];
-    const name = codeBlock.title || `part_${index + 1}`;
-    let codeFileName = path.basename(name);
-    let fileExtension = path.extname(codeFileName);
-
-    if (!fileExtension) {
-      fileExtension = '.js';
-      codeFileName += fileExtension;
-    }
-
-    codeFileName = sanitizeFilename(codeFileName) || `part_${index + 1}.js`;
-    const codeFilePath = path.join(outputDir, codeFileName);
-    let fileContent = codeBlock.code || '';
-    if (shouldAddSourceComments && !fileContent.includes('Downloaded with opdl')) {
-      const commentBlock = buildCommentBlock(sketchInfo, fileExtension);
-      fileContent = `${commentBlock}${fileContent.startsWith('\n') ? '' : '\n'}${fileContent}`;
-    }
-    fs.writeFileSync(codeFilePath, fileContent, 'utf8');
-
+    const { codeFilePath, sanitizedCodeBlock } = writeCodeFile({
+      outputDir,
+      codeBlock: codeParts[index],
+      index,
+      sketchInfo,
+      addSourceComments: shouldAddSourceComments,
+      fallbackBase: 'part',
+      usedNames: rootUsedNames,
+    });
     savedCodeFiles.push(codeFilePath);
-    sanitizedCodeParts.push({ ...codeBlock, title: codeFileName });
+    sanitizedCodeParts.push(sanitizedCodeBlock);
   }
 
   const assetBaseUrl = sketchInfo.metadata?.fileBase;
@@ -139,6 +131,16 @@ const downloadSketch = async (sketchInfo, options = {}) => {
 
   if (finalOptions.createOpMetadata) {
     createOpMetadata(sketchInfo, outputDir, finalOptions);
+  }
+
+  if (sketchInfo.tutorial) {
+    try {
+      writeTutorial(sketchInfo.tutorial, outputDir, sketchInfo, finalOptions);
+    } catch (error) {
+      if (!finalOptions.quiet) {
+        console.warn(`opdl: failed to write tutorial bundle: ${error.message}`);
+      }
+    }
   }
 
   // Set up Vite project if requested

--- a/src/download/service.js
+++ b/src/download/service.js
@@ -4,6 +4,11 @@
  */
 
 const { OpenProcessingClient } = require('../api/client');
+const {
+  fetchTutorialBundle,
+  httpGetViaClient,
+  isTutorialMode,
+} = require('./tutorialFetcher');
 
 /**
  * @typedef {Object} SketchInfo
@@ -117,6 +122,23 @@ class DownloadService {
           // Parent not available - not critical
           if (!quiet) {
             console.warn(`Could not fetch parent sketch: ${error.message}`);
+          }
+        }
+      }
+
+      // 6. If tutorial, fetch tutorial bundle (non-fatal on failure).
+      if (isTutorialMode(sketch.tutorialMode)) {
+        try {
+          const bundle = await fetchTutorialBundle({
+            httpGet: httpGetViaClient(this.client),
+            sketchId: id,
+            quiet,
+            verbose: options.verbose,
+          });
+          sketchInfo.tutorial = bundle;
+        } catch (error) {
+          if (!quiet) {
+            console.warn(`Could not fetch tutorial bundle: ${error.message}`);
           }
         }
       }

--- a/src/download/tutorialFetcher.js
+++ b/src/download/tutorialFetcher.js
@@ -1,0 +1,172 @@
+const axios = require('axios');
+
+const DEFAULT_SLEEP = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const PAGE_RETRY_DELAYS_MS = [1000, 2000]; // 2 backoff sleeps -> 3 attempts total
+const TUTORIAL_INDEX_RE = /^\/api\/tutorial\/(\d+)\/?$/;
+const TUTORIAL_PAGE_RE = /^\/api\/tutorial\/(\d+)\/page\/(\d+)\/?$/;
+
+/**
+ * Determine whether a sketch's tutorialMode value indicates it is a tutorial.
+ * Explicitly handles the historical numeric variant from /api/sketch/ and the
+ * string variants from /api/tutorial/.
+ *
+ * @param {*} value
+ * @returns {boolean}
+ */
+function isTutorialMode(value) {
+  if (value === 1 || value === '1') return true;
+  if (value === 'normal' || value === 'singleCode') return true;
+  return false;
+}
+
+function is429(error) {
+  if (!error) return false;
+  if (error.status === 429) return true;
+  if (error.response && error.response.status === 429) return true;
+  return false;
+}
+
+/**
+ * Fetch a tutorial bundle (index + all pages) for a sketch.
+ *
+ * @param {Object} params
+ * @param {(path: string) => Promise<any>} params.httpGet - Transport-agnostic GET that returns the parsed body or throws.
+ * @param {number|string} params.sketchId
+ * @param {boolean} [params.quiet]
+ * @param {boolean} [params.verbose]
+ * @param {(ms: number) => Promise<void>} [params.sleep] - Injectable sleep for tests.
+ * @returns {Promise<{ tutorial: any, pages: Array, failedPages: Array }>}
+ */
+async function fetchTutorialBundle({
+  httpGet,
+  sketchId,
+  quiet = false,
+  verbose = false,
+  sleep = DEFAULT_SLEEP,
+}) {
+  const tutorial = await httpGet(`/api/tutorial/${sketchId}`);
+  const totalPages = Number(tutorial?.totalPages);
+  const pages = [];
+  const failedPages = [];
+
+  if (!Number.isFinite(totalPages) || totalPages <= 0) {
+    return { tutorial, pages, failedPages };
+  }
+
+  for (let pageNumber = 1; pageNumber <= totalPages; pageNumber += 1) {
+    let attempt = 0;
+    let lastError = null;
+    let succeeded = false;
+
+    while (attempt < PAGE_RETRY_DELAYS_MS.length + 1) {
+      try {
+        const page = await httpGet(`/api/tutorial/${sketchId}/page/${pageNumber}/`);
+        pages.push({
+          pageNumber,
+          markdown: String(page?.markdown ?? ''),
+          codeObjects: Array.isArray(page?.codeObjects) ? page.codeObjects : [],
+          raw: page,
+        });
+        succeeded = true;
+        break;
+      } catch (error) {
+        lastError = error;
+        if (!is429(error)) {
+          // Non-429: no retry.
+          break;
+        }
+        if (attempt < PAGE_RETRY_DELAYS_MS.length) {
+          if (verbose && !quiet) {
+            console.warn(
+              `opdl: tutorial page ${pageNumber} hit 429, retrying after ${PAGE_RETRY_DELAYS_MS[attempt]}ms`
+            );
+          }
+          await sleep(PAGE_RETRY_DELAYS_MS[attempt]);
+        }
+        attempt += 1;
+      }
+    }
+
+    if (!succeeded) {
+      failedPages.push({ pageNumber, error: lastError });
+    }
+  }
+
+  return { tutorial, pages, failedPages };
+}
+
+/**
+ * Adapter: route paths through an OpenProcessingClient instance.
+ * Strictly matches the two supported path shapes; throws otherwise.
+ *
+ * @param {import('../api/client').OpenProcessingClient} client
+ * @returns {(path: string) => Promise<any>}
+ */
+function httpGetViaClient(client) {
+  return async (requestPath) => {
+    let match = requestPath.match(TUTORIAL_INDEX_RE);
+    if (match) {
+      return client.getTutorial(Number(match[1]));
+    }
+    match = requestPath.match(TUTORIAL_PAGE_RE);
+    if (match) {
+      return client.getTutorialPage(Number(match[1]), Number(match[2]));
+    }
+    throw new Error(`httpGetViaClient: unsupported path ${requestPath}`);
+  };
+}
+
+/**
+ * Adapter: legacy axios path used by fetcher.js. Bypasses fetchData() because
+ * fetchData() discards HTTP status; we need 429 to be visible for retry logic.
+ *
+ * @param {Object} [opts]
+ * @param {string} [opts.token]
+ * @param {boolean} [opts.quiet]
+ * @returns {(path: string) => Promise<any>}
+ */
+function httpGetViaAxios({ token, quiet = false } = {}) {
+  const headers = token ? { Authorization: `Bearer ${token}` } : {};
+  return async (requestPath) => {
+    const url = `https://openprocessing.org${requestPath}`;
+    let response;
+    try {
+      response = await axios.get(url, { headers, validateStatus: () => true });
+    } catch (error) {
+      const message = error.response?.data?.message || error.message || 'Unknown error';
+      const err = new Error(message);
+      err.cause = error;
+      throw err;
+    }
+
+    if (response.status === 429) {
+      const err = new Error('Rate limit exceeded');
+      err.status = 429;
+      err.response = response;
+      throw err;
+    }
+
+    const body = response.data;
+    if (body && body.success === false) {
+      const err = new Error(body.message || 'API error');
+      err.status = response.status;
+      throw err;
+    }
+
+    if (response.status >= 400) {
+      const message = body?.message || `HTTP ${response.status} for ${requestPath}`;
+      const err = new Error(message);
+      err.status = response.status;
+      throw err;
+    }
+
+    return body;
+  };
+}
+
+module.exports = {
+  fetchTutorialBundle,
+  httpGetViaClient,
+  httpGetViaAxios,
+  isTutorialMode,
+};

--- a/src/download/tutorialWriter.js
+++ b/src/download/tutorialWriter.js
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const path = require('path');
+
+const { ensureDirectoryExists } = require('../utils');
+const { writeCodeFile } = require('./codeFileWriter');
+
+const META_DIR = 'metadata';
+const TUTORIAL_DIR = 'tutorial';
+
+function normalizeFailedPages(failedPages) {
+  return (failedPages || []).map((entry) => ({
+    pageNumber: entry.pageNumber,
+    error: entry.error?.message || String(entry.error || 'Unknown error'),
+    status: entry.error?.status ?? null,
+  }));
+}
+
+/**
+ * Write a tutorial bundle to disk alongside the existing sketch download.
+ *
+ * @param {Object} bundle - { tutorial, pages, failedPages } from fetchTutorialBundle.
+ * @param {string} outputDir - Sketch output directory.
+ * @param {Object} sketchInfo - For code-file attribution.
+ * @param {Object} [options]
+ * @param {boolean} [options.saveMetadata]
+ * @param {boolean} [options.addSourceComments]
+ * @param {boolean} [options.quiet]
+ * @returns {{ pagesWritten: number, failedPages: Array }}
+ */
+function writeTutorial(bundle, outputDir, sketchInfo, options = {}) {
+  if (!bundle || !bundle.tutorial) {
+    return { pagesWritten: 0, failedPages: [] };
+  }
+
+  const { tutorial, pages = [], failedPages = [] } = bundle;
+  const normalizedFailedPages = normalizeFailedPages(failedPages);
+
+  if (options.saveMetadata) {
+    const metadataDir = path.join(outputDir, META_DIR);
+    ensureDirectoryExists(metadataDir);
+    const tutorialMetaPath = path.join(metadataDir, 'tutorial.json');
+    const payload = { ...tutorial, failedPages: normalizedFailedPages };
+    fs.writeFileSync(tutorialMetaPath, JSON.stringify(payload, null, 2), 'utf8');
+  }
+
+  const tutorialRoot = path.join(outputDir, TUTORIAL_DIR);
+  const mode = tutorial.tutorialMode;
+  let pagesWritten = 0;
+
+  for (const page of pages) {
+    const pageNumber = Number(page.pageNumber);
+    if (!Number.isFinite(pageNumber) || pageNumber <= 0) {
+      continue;
+    }
+
+    const pageDir = path.join(tutorialRoot, `page_${pageNumber}`);
+    ensureDirectoryExists(pageDir);
+
+    const markdown = String(page.markdown ?? '');
+    fs.writeFileSync(path.join(pageDir, 'README.md'), markdown, 'utf8');
+
+    if (mode === 'normal' && Array.isArray(page.codeObjects) && page.codeObjects.length) {
+      const pageUsedNames = new Set();
+      page.codeObjects.forEach((codeBlock, index) => {
+        writeCodeFile({
+          outputDir: pageDir,
+          codeBlock,
+          index,
+          sketchInfo,
+          addSourceComments: !!options.addSourceComments,
+          fallbackBase: 'code',
+          usedNames: pageUsedNames,
+        });
+      });
+    }
+
+    pagesWritten += 1;
+  }
+
+  if (normalizedFailedPages.length > 0 && !options.quiet) {
+    const list = normalizedFailedPages.map((f) => f.pageNumber).join(', ');
+    console.warn(`opdl: tutorial pages failed to download: ${list}`);
+  }
+
+  return { pagesWritten, failedPages: normalizedFailedPages };
+}
+
+module.exports = { writeTutorial };

--- a/src/download/tutorialWriter.js
+++ b/src/download/tutorialWriter.js
@@ -7,11 +7,18 @@ const { writeCodeFile } = require('./codeFileWriter');
 const META_DIR = 'metadata';
 const TUTORIAL_DIR = 'tutorial';
 
+function extractStatus(error) {
+  if (!error) return null;
+  if (typeof error.status === 'number') return error.status;
+  if (typeof error.response?.status === 'number') return error.response.status;
+  return null;
+}
+
 function normalizeFailedPages(failedPages) {
   return (failedPages || []).map((entry) => ({
     pageNumber: entry.pageNumber,
     error: entry.error?.message || String(entry.error || 'Unknown error'),
-    status: entry.error?.status ?? null,
+    status: extractStatus(entry.error),
   }));
 }
 

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -1,5 +1,10 @@
 const axios = require('axios');
 const { validateSketch, VALIDATION_REASONS, MESSAGES } = require('./api/validator');
+const {
+  fetchTutorialBundle,
+  httpGetViaAxios,
+  isTutorialMode,
+} = require('./download/tutorialFetcher');
 
 const logError = (message, quiet) => {
   if (!quiet) {
@@ -180,6 +185,20 @@ const fetchSketchInfo = async (sketchId, options = {}) => {
 
   sketchInfo.metadata = sketchInfo.metadata || {};
   sketchInfo.metadata.libraries = sketchInfo.metadata.libraries || sketchInfo.libraries;
+
+  if (isTutorialMode(sketchInfo.metadata.tutorialMode)) {
+    try {
+      const bundle = await fetchTutorialBundle({
+        httpGet: httpGetViaAxios({ token, quiet }),
+        sketchId: parsedId,
+        quiet,
+        verbose: options.verbose,
+      });
+      sketchInfo.tutorial = bundle;
+    } catch (error) {
+      logError(`Error fetching tutorial bundle for sketch ${parsedId}: ${error.message}`, quiet);
+    }
+  }
 
   return sketchInfo;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,11 @@ const opdl = async (sketchId, options = {}) => {
     return result;
   }
 
-  const sketchInfo = await fetchSketchInfo(sketchId, { quiet: mergedOptions.quiet, token: mergedOptions.token });
+  const sketchInfo = await fetchSketchInfo(sketchId, {
+    quiet: mergedOptions.quiet,
+    verbose: mergedOptions.verbose,
+    token: mergedOptions.token,
+  });
 
   if (!sketchInfo) {
     result.sketchInfo.error = 'Invalid sketch ID';

--- a/src/types/api.js
+++ b/src/types/api.js
@@ -29,6 +29,12 @@
  * @property {number} views - Number of views
  * @property {boolean} isPublic - Whether sketch is public
  * @property {boolean} isFeatured - Whether sketch is featured
+ * @property {number|string} [tutorialMode] - Tutorial flag. /api/sketch returns 0|1; /api/tutorial returns "normal"|"singleCode"
+ */
+
+/**
+ * @typedef {import('../api/types').TutorialPage} TutorialPage
+ * @typedef {import('../api/types').TutorialBundle} TutorialBundle
  */
 
 /**

--- a/tests/api/client.test.mjs
+++ b/tests/api/client.test.mjs
@@ -92,6 +92,41 @@ describe('OpenProcessingClient', () => {
     });
   });
 
+  describe('getTutorial / getTutorialPage', () => {
+    it('returns tutorial index on 200', async () => {
+      const payload = { visualID: 2798401, totalPages: 2, tutorialMode: 'normal' };
+      nock(BASE_URL).get('/api/tutorial/2798401').reply(200, payload);
+      const result = await client.getTutorial(2798401);
+      assert.deepEqual(result, payload);
+    });
+
+    it('throws on { success: false } envelope', async () => {
+      nock(BASE_URL)
+        .get('/api/tutorial/2798401')
+        .reply(200, { success: false, message: 'nope' });
+      await assert.rejects(() => client.getTutorial(2798401), { message: /nope/ });
+    });
+
+    it('propagates 429 through interceptor', async () => {
+      nock(BASE_URL).get('/api/tutorial/2798401').reply(429);
+      await assert.rejects(() => client.getTutorial(2798401), {
+        message: /Rate limit exceeded/,
+      });
+    });
+
+    it('throws on non-2xx (e.g. 500)', async () => {
+      nock(BASE_URL).get('/api/tutorial/2798401/page/1/').reply(500);
+      await assert.rejects(() => client.getTutorialPage(2798401, 1));
+    });
+
+    it('returns tutorial page on 200', async () => {
+      const payload = { markdown: 'hi', codeObjects: [] };
+      nock(BASE_URL).get('/api/tutorial/2798401/page/2/').reply(200, payload);
+      const result = await client.getTutorialPage(2798401, 2);
+      assert.deepEqual(result, payload);
+    });
+  });
+
   describe('getSketchForks', () => {
     it('should fetch sketch forks', async () => {
       const mockForks = [

--- a/tests/download/codeFileWriter.test.mjs
+++ b/tests/download/codeFileWriter.test.mjs
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { writeCodeFile } from '../../src/download/codeFileWriter.js';
+
+describe('writeCodeFile', () => {
+  let dir;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-cfw-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes a file using the codeBlock title, sanitized', () => {
+    const used = new Set();
+    const result = writeCodeFile({
+      outputDir: dir,
+      codeBlock: { title: 'sketch.js', code: 'console.log(1);' },
+      index: 0,
+      sketchInfo: { sketchId: 1 },
+      addSourceComments: false,
+      usedNames: used,
+    });
+    expect(result.codeFileName).toBe('sketch.js');
+    expect(fs.readFileSync(result.codeFilePath, 'utf8')).toBe('console.log(1);');
+  });
+
+  it('falls back to fallbackBase_N.js when title is missing', () => {
+    const used = new Set();
+    const result = writeCodeFile({
+      outputDir: dir,
+      codeBlock: { code: 'x' },
+      index: 2,
+      sketchInfo: {},
+      addSourceComments: false,
+      fallbackBase: 'code',
+      usedNames: used,
+    });
+    expect(result.codeFileName).toBe('code_3.js');
+  });
+
+  it('appends .js when extension is missing', () => {
+    const used = new Set();
+    const result = writeCodeFile({
+      outputDir: dir,
+      codeBlock: { title: 'mySketch', code: '' },
+      index: 0,
+      sketchInfo: {},
+      addSourceComments: false,
+      usedNames: used,
+    });
+    expect(result.codeFileName).toBe('mySketch.js');
+  });
+
+  it('prepends attribution block when addSourceComments is true', () => {
+    const used = new Set();
+    const result = writeCodeFile({
+      outputDir: dir,
+      codeBlock: { title: 'a.js', code: 'noop();' },
+      index: 0,
+      sketchInfo: { sketchId: 42, title: 'T', author: 'A' },
+      addSourceComments: true,
+      usedNames: used,
+    });
+    const content = fs.readFileSync(result.codeFilePath, 'utf8');
+    expect(content).toMatch(/Downloaded with opdl/);
+    expect(content).toMatch(/noop\(\);/);
+  });
+
+  it('de-duplicates colliding sanitized names', () => {
+    const used = new Set();
+    writeCodeFile({
+      outputDir: dir,
+      codeBlock: { title: 'foo.js', code: 'a' },
+      index: 0,
+      sketchInfo: {},
+      addSourceComments: false,
+      usedNames: used,
+    });
+    const second = writeCodeFile({
+      outputDir: dir,
+      codeBlock: { title: 'foo.js', code: 'b' },
+      index: 1,
+      sketchInfo: {},
+      addSourceComments: false,
+      usedNames: used,
+    });
+    expect(second.codeFileName).toBe('foo_2.js');
+    expect(fs.readFileSync(path.join(dir, 'foo.js'), 'utf8')).toBe('a');
+    expect(fs.readFileSync(path.join(dir, 'foo_2.js'), 'utf8')).toBe('b');
+  });
+
+  it('sanitizes path-traversal titles into outputDir', () => {
+    const used = new Set();
+    const result = writeCodeFile({
+      outputDir: dir,
+      codeBlock: { title: '../../etc/passwd', code: 'x' },
+      index: 0,
+      sketchInfo: {},
+      addSourceComments: false,
+      usedNames: used,
+    });
+    const resolved = path.resolve(result.codeFilePath);
+    expect(resolved.startsWith(path.resolve(dir))).toBe(true);
+  });
+});

--- a/tests/download/downloader.test.mjs
+++ b/tests/download/downloader.test.mjs
@@ -604,4 +604,91 @@ describe('downloader', () => {
       expect(fs.existsSync(path.join(testDir, 'valid.png'))).toBe(true);
     });
   });
+
+  describe('root-level code-file collisions', () => {
+    it('writes the second colliding part as name_2.js instead of overwriting', async () => {
+      const sketchInfo = {
+        sketchId: 1,
+        title: 'T',
+        author: 'A',
+        codeParts: [
+          { title: 'sketch.js', code: 'one' },
+          { title: 'sketch.js', code: 'two' },
+        ],
+        files: [],
+        metadata: { mode: 'p5js' },
+      };
+
+      await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: false,
+      });
+
+      expect(fs.readFileSync(path.join(testDir, 'sketch.js'), 'utf8')).toBe('one');
+      expect(fs.readFileSync(path.join(testDir, 'sketch_2.js'), 'utf8')).toBe('two');
+    });
+  });
+
+  describe('tutorial bundle wiring', () => {
+    it('produces tutorial/ tree when sketchInfo.tutorial is present', async () => {
+      const sketchInfo = {
+        sketchId: 1,
+        title: 'T',
+        author: 'A',
+        codeParts: [{ title: 'sketch.js', code: 'main' }],
+        files: [],
+        metadata: { mode: 'p5js' },
+        tutorial: {
+          tutorial: { tutorialMode: 'normal', totalPages: 1, totalPagesRaw: 1 },
+          pages: [{
+            pageNumber: 1,
+            markdown: '# Page',
+            codeObjects: [{ title: 'mySketch.js', code: 'page code' }],
+          }],
+          failedPages: [],
+        },
+      };
+
+      await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: false,
+      });
+
+      expect(fs.existsSync(path.join(testDir, 'tutorial/page_1/README.md'))).toBe(true);
+      expect(fs.readFileSync(path.join(testDir, 'tutorial/page_1/mySketch.js'), 'utf8')).toBe('page code');
+    });
+
+    it('produces no tutorial/ tree when sketchInfo.tutorial is absent', async () => {
+      const sketchInfo = {
+        sketchId: 1,
+        title: 'T',
+        author: 'A',
+        codeParts: [{ title: 'sketch.js', code: 'main' }],
+        files: [],
+        metadata: { mode: 'p5js' },
+      };
+
+      await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: false,
+      });
+
+      expect(fs.existsSync(path.join(testDir, 'tutorial'))).toBe(false);
+    });
+  });
 });

--- a/tests/download/fetcher.test.mjs
+++ b/tests/download/fetcher.test.mjs
@@ -349,4 +349,71 @@ describe('fetcher', () => {
       consoleSpy.mockRestore();
     });
   });
+
+  describe('tutorial mode (legacy fetcher path)', () => {
+    function stubBaselineSketch(sketchId, { tutorialMode } = {}) {
+      nock('https://openprocessing.org')
+        .get(`/api/sketch/${sketchId}`)
+        .reply(200, {
+          visualID: sketchId,
+          title: 'T',
+          mode: 'p5js',
+          userID: 9,
+          tutorialMode,
+        });
+      nock('https://openprocessing.org')
+        .get(`/api/sketch/${sketchId}/code`)
+        .reply(200, []);
+      nock('https://openprocessing.org')
+        .get(`/api/sketch/${sketchId}/files?limit=100&offset=0`)
+        .reply(200, []);
+      nock('https://openprocessing.org')
+        .get(`/api/sketch/${sketchId}/libraries?limit=100&offset=0`)
+        .reply(200, []);
+      nock('https://openprocessing.org')
+        .get(`/api/user/9`)
+        .reply(200, { fullname: 'U' });
+    }
+
+    it('attaches tutorial bundle when metadata.tutorialMode is truthy', async () => {
+      const sketchId = 555;
+      stubBaselineSketch(sketchId, { tutorialMode: 1 });
+      nock('https://openprocessing.org')
+        .get(`/api/tutorial/${sketchId}`)
+        .reply(200, { visualID: sketchId, totalPages: 1, tutorialMode: 'normal' });
+      nock('https://openprocessing.org')
+        .get(`/api/tutorial/${sketchId}/page/1/`)
+        .reply(200, { markdown: '# hi', codeObjects: [] });
+
+      const result = await fetchSketchInfo(sketchId, { quiet: true });
+      expect(result.tutorial).toBeDefined();
+      expect(result.tutorial.tutorial.totalPages).toBe(1);
+      expect(result.tutorial.pages).toHaveLength(1);
+      expect(result.tutorial.failedPages).toEqual([]);
+    });
+
+    it('does not fetch tutorial endpoints when tutorialMode is falsy', async () => {
+      const sketchId = 556;
+      stubBaselineSketch(sketchId, { tutorialMode: 0 });
+      // No nock for /api/tutorial — any call would error.
+      const result = await fetchSketchInfo(sketchId, { quiet: true });
+      expect(result.tutorial).toBeUndefined();
+    });
+
+    it('preserves error.status on 500 page failures (adapter parity)', async () => {
+      const sketchId = 557;
+      stubBaselineSketch(sketchId, { tutorialMode: 'normal' });
+      nock('https://openprocessing.org')
+        .get(`/api/tutorial/${sketchId}`)
+        .reply(200, { visualID: sketchId, totalPages: 1, tutorialMode: 'normal' });
+      nock('https://openprocessing.org')
+        .get(`/api/tutorial/${sketchId}/page/1/`)
+        .reply(500, { message: 'boom' });
+
+      const result = await fetchSketchInfo(sketchId, { quiet: true });
+      expect(result.tutorial.failedPages).toHaveLength(1);
+      expect(result.tutorial.failedPages[0].pageNumber).toBe(1);
+      expect(result.tutorial.failedPages[0].error.status).toBe(500);
+    });
+  });
 });

--- a/tests/download/service.test.mjs
+++ b/tests/download/service.test.mjs
@@ -1,6 +1,10 @@
-import { describe, it, beforeEach } from 'vitest';
+import { describe, it, beforeEach, afterEach } from 'vitest';
 import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
 import { DownloadService } from '../../src/download/service.js';
+import { writeTutorial } from '../../src/download/tutorialWriter.js';
 
 describe('DownloadService', () => {
   let service;
@@ -367,6 +371,43 @@ describe('DownloadService', () => {
         assert.equal(result.tutorial, undefined);
         assert.equal(result.available, true);
         assert.equal(result.title, 'T');
+      });
+
+      it('preserves HTTP status in metadata/tutorial.json on client-path 500 (adapter parity)', async () => {
+        // Drive DownloadService -> httpGetViaClient -> client.getTutorialPage,
+        // then serialize via writeTutorial and assert status is preserved.
+        // The client method lets axios throw natively (error.response.status),
+        // so this exercises the extractStatus fallback path.
+        const axiosLikeError = new Error('Request failed with status code 500');
+        axiosLikeError.response = { status: 500, data: { message: 'boom' } };
+
+        mockClient.getSketch = async () => ({
+          visualID: 1, title: 'T', mode: 'p5js', userID: 9, tutorialMode: 1,
+        });
+        mockClient.getUser = async () => ({ fullname: 'U' });
+        mockClient.getSketchCode = async () => [];
+        mockClient.getTutorial = async () => ({
+          visualID: 1, totalPages: 1, tutorialMode: 'normal',
+        });
+        mockClient.getTutorialPage = async () => { throw axiosLikeError; };
+
+        service = new DownloadService(mockClient);
+        const result = await service.getCompleteSketchInfo(1, { quiet: true });
+
+        assert.equal(result.tutorial.failedPages.length, 1);
+        // Raw error still in memory.
+        assert.equal(result.tutorial.failedPages[0].error.response.status, 500);
+
+        const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-svc-'));
+        try {
+          writeTutorial(result.tutorial, tmp, result, { saveMetadata: true, quiet: true });
+          const meta = JSON.parse(fs.readFileSync(path.join(tmp, 'metadata/tutorial.json'), 'utf8'));
+          assert.equal(meta.failedPages.length, 1);
+          assert.equal(meta.failedPages[0].pageNumber, 1);
+          assert.equal(meta.failedPages[0].status, 500);
+        } finally {
+          fs.rmSync(tmp, { recursive: true, force: true });
+        }
       });
     });
   });

--- a/tests/download/service.test.mjs
+++ b/tests/download/service.test.mjs
@@ -313,5 +313,61 @@ describe('DownloadService', () => {
       console.warn = originalWarn;
       assert.equal(warnCalled, false);
     });
+
+    describe('tutorial mode', () => {
+      it('attaches tutorial bundle when sketch.tutorialMode is set', async () => {
+        mockClient.getSketch = async () => ({
+          visualID: 1, title: 'T', mode: 'p5js', userID: 9, tutorialMode: 1,
+        });
+        mockClient.getUser = async () => ({ fullname: 'U' });
+        mockClient.getSketchCode = async () => [];
+        mockClient.getTutorial = async () => ({
+          visualID: 1, totalPages: 1, tutorialMode: 'normal',
+        });
+        mockClient.getTutorialPage = async () => ({
+          markdown: '# hi', codeObjects: [],
+        });
+
+        service = new DownloadService(mockClient);
+        const result = await service.getCompleteSketchInfo(1, { quiet: true });
+
+        assert.ok(result.tutorial);
+        assert.equal(result.tutorial.tutorial.totalPages, 1);
+        assert.equal(result.tutorial.pages.length, 1);
+        assert.deepEqual(result.tutorial.failedPages, []);
+      });
+
+      it('does not attach tutorial bundle when tutorialMode is falsy', async () => {
+        mockClient.getSketch = async () => ({
+          visualID: 1, title: 'T', mode: 'p5js', userID: 9, tutorialMode: 0,
+        });
+        mockClient.getUser = async () => ({ fullname: 'U' });
+        mockClient.getSketchCode = async () => [];
+        mockClient.getTutorial = async () => {
+          throw new Error('should not be called');
+        };
+
+        service = new DownloadService(mockClient);
+        const result = await service.getCompleteSketchInfo(1, { quiet: true });
+
+        assert.equal(result.tutorial, undefined);
+      });
+
+      it('treats tutorial-index failure as non-fatal', async () => {
+        mockClient.getSketch = async () => ({
+          visualID: 1, title: 'T', mode: 'p5js', userID: 9, tutorialMode: 1,
+        });
+        mockClient.getUser = async () => ({ fullname: 'U' });
+        mockClient.getSketchCode = async () => [];
+        mockClient.getTutorial = async () => { throw new Error('index 500'); };
+
+        service = new DownloadService(mockClient);
+        const result = await service.getCompleteSketchInfo(1, { quiet: true });
+
+        assert.equal(result.tutorial, undefined);
+        assert.equal(result.available, true);
+        assert.equal(result.title, 'T');
+      });
+    });
   });
 });

--- a/tests/download/tutorialFetcher.test.mjs
+++ b/tests/download/tutorialFetcher.test.mjs
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  fetchTutorialBundle,
+  isTutorialMode,
+} from '../../src/download/tutorialFetcher.js';
+
+const noopSleep = vi.fn(() => Promise.resolve());
+
+function makeHttpGet(routes) {
+  // routes: Map<path, () => Promise|value | array of responses for sequential calls>
+  const callCounts = new Map();
+  return async (path) => {
+    const handler = routes[path];
+    if (handler === undefined) {
+      throw Object.assign(new Error(`No route for ${path}`), { status: 404 });
+    }
+    if (Array.isArray(handler)) {
+      const count = callCounts.get(path) || 0;
+      callCounts.set(path, count + 1);
+      const next = handler[Math.min(count, handler.length - 1)];
+      if (next instanceof Error) throw next;
+      if (typeof next === 'function') return next();
+      return next;
+    }
+    if (handler instanceof Error) throw handler;
+    if (typeof handler === 'function') return handler();
+    return handler;
+  };
+}
+
+describe('isTutorialMode', () => {
+  it.each([
+    [1, true],
+    ['1', true],
+    ['normal', true],
+    ['singleCode', true],
+    [0, false],
+    ['0', false],
+    [null, false],
+    [undefined, false],
+    [false, false],
+    ['', false],
+    ['nope', false],
+  ])('%s -> %s', (input, expected) => {
+    expect(isTutorialMode(input)).toBe(expected);
+  });
+});
+
+describe('fetchTutorialBundle', () => {
+  it('normal multi-page happy path (locks fixture for visualID 2798401)', async () => {
+    const tutorial = {
+      visualID: 2798401,
+      totalPages: 2,
+      tutorialMode: 'normal',
+      tutorialID: 999,
+    };
+    const page1 = { pageID: 1, markdown: '# Page 1', codeObjects: [] };
+    const page2 = {
+      pageID: 2,
+      markdown: '# Page 2',
+      codeObjects: [{ title: 'mySketch', code: 'function setup(){}' }],
+    };
+    const httpGet = makeHttpGet({
+      '/api/tutorial/2798401': tutorial,
+      '/api/tutorial/2798401/page/1/': page1,
+      '/api/tutorial/2798401/page/2/': page2,
+    });
+    const sleep = vi.fn();
+    const bundle = await fetchTutorialBundle({
+      httpGet,
+      sketchId: 2798401,
+      sleep,
+    });
+    expect(bundle.tutorial.totalPages).toBe(2);
+    expect(bundle.pages).toHaveLength(2);
+    expect(bundle.pages[1].codeObjects[0].title).toBe('mySketch');
+    expect(bundle.failedPages).toEqual([]);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('singleCode mode returns pages with markdown only', async () => {
+    const httpGet = makeHttpGet({
+      '/api/tutorial/5': { totalPages: 1, tutorialMode: 'singleCode' },
+      '/api/tutorial/5/page/1/': { markdown: 'hi', codeObjects: [{ title: 'x', code: '' }] },
+    });
+    const bundle = await fetchTutorialBundle({ httpGet, sketchId: 5, sleep: noopSleep });
+    expect(bundle.tutorial.tutorialMode).toBe('singleCode');
+    expect(bundle.pages[0].markdown).toBe('hi');
+  });
+
+  it('retries on 429 then succeeds', async () => {
+    const rateLimit = Object.assign(new Error('Rate limit'), { status: 429 });
+    const httpGet = makeHttpGet({
+      '/api/tutorial/1': { totalPages: 1, tutorialMode: 'normal' },
+      '/api/tutorial/1/page/1/': [rateLimit, { markdown: 'ok', codeObjects: [] }],
+    });
+    const sleep = vi.fn(() => Promise.resolve());
+    const bundle = await fetchTutorialBundle({ httpGet, sketchId: 1, sleep });
+    expect(bundle.pages).toHaveLength(1);
+    expect(bundle.failedPages).toEqual([]);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(1000);
+  });
+
+  it('429 on all attempts -> failedPages with status 429, 2 sleeps', async () => {
+    const rateLimit = () => Object.assign(new Error('Rate limit'), { status: 429 });
+    const httpGet = makeHttpGet({
+      '/api/tutorial/1': { totalPages: 1, tutorialMode: 'normal' },
+      '/api/tutorial/1/page/1/': [rateLimit(), rateLimit(), rateLimit()],
+    });
+    const sleep = vi.fn(() => Promise.resolve());
+    const bundle = await fetchTutorialBundle({ httpGet, sketchId: 1, sleep });
+    expect(bundle.pages).toHaveLength(0);
+    expect(bundle.failedPages).toHaveLength(1);
+    expect(bundle.failedPages[0].pageNumber).toBe(1);
+    expect(bundle.failedPages[0].error.status).toBe(429);
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep.mock.calls.map((c) => c[0])).toEqual([1000, 2000]);
+  });
+
+  it('non-429 error -> no retry, lands in failedPages immediately', async () => {
+    const serverError = Object.assign(new Error('boom'), { status: 500 });
+    const httpGet = makeHttpGet({
+      '/api/tutorial/1': { totalPages: 1, tutorialMode: 'normal' },
+      '/api/tutorial/1/page/1/': serverError,
+    });
+    const sleep = vi.fn(() => Promise.resolve());
+    const bundle = await fetchTutorialBundle({ httpGet, sketchId: 1, sleep });
+    expect(bundle.failedPages).toHaveLength(1);
+    expect(bundle.failedPages[0].error.status).toBe(500);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it('one failing page does not abort subsequent pages', async () => {
+    const httpGet = makeHttpGet({
+      '/api/tutorial/1': { totalPages: 3, tutorialMode: 'normal' },
+      '/api/tutorial/1/page/1/': { markdown: 'a', codeObjects: [] },
+      '/api/tutorial/1/page/2/': Object.assign(new Error('500'), { status: 500 }),
+      '/api/tutorial/1/page/3/': { markdown: 'c', codeObjects: [] },
+    });
+    const bundle = await fetchTutorialBundle({ httpGet, sketchId: 1, sleep: noopSleep });
+    expect(bundle.pages.map((p) => p.pageNumber)).toEqual([1, 3]);
+    expect(bundle.failedPages.map((f) => f.pageNumber)).toEqual([2]);
+  });
+
+  it('tutorial-index failure throws (bundle-level)', async () => {
+    const httpGet = makeHttpGet({
+      '/api/tutorial/9': Object.assign(new Error('404'), { status: 404 }),
+    });
+    await expect(
+      fetchTutorialBundle({ httpGet, sketchId: 9, sleep: noopSleep })
+    ).rejects.toThrow('404');
+  });
+
+  it('undefined markdown is normalized to empty string', async () => {
+    const httpGet = makeHttpGet({
+      '/api/tutorial/1': { totalPages: 1, tutorialMode: 'normal' },
+      '/api/tutorial/1/page/1/': { codeObjects: [] },
+    });
+    const bundle = await fetchTutorialBundle({ httpGet, sketchId: 1, sleep: noopSleep });
+    expect(bundle.pages[0].markdown).toBe('');
+  });
+});

--- a/tests/download/tutorialWriter.test.mjs
+++ b/tests/download/tutorialWriter.test.mjs
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { writeTutorial } from '../../src/download/tutorialWriter.js';
+
+function makeBundle(overrides = {}) {
+  return {
+    tutorial: {
+      visualID: 1,
+      tutorialID: 99,
+      totalPages: 2,
+      tutorialMode: 'normal',
+      ...overrides.tutorial,
+    },
+    pages: overrides.pages || [
+      { pageNumber: 1, markdown: '# One', codeObjects: [{ title: 'a.js', code: 'one' }] },
+      { pageNumber: 2, markdown: '# Two', codeObjects: [{ title: 'b.js', code: 'two' }] },
+    ],
+    failedPages: overrides.failedPages || [],
+  };
+}
+
+describe('writeTutorial', () => {
+  let dir;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-tw-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('writes README.md and code per page in normal mode', () => {
+    const res = writeTutorial(makeBundle(), dir, { sketchId: 1 }, { saveMetadata: false });
+    expect(res.pagesWritten).toBe(2);
+    expect(fs.readFileSync(path.join(dir, 'tutorial/page_1/README.md'), 'utf8')).toBe('# One');
+    expect(fs.readFileSync(path.join(dir, 'tutorial/page_1/a.js'), 'utf8')).toBe('one');
+    expect(fs.readFileSync(path.join(dir, 'tutorial/page_2/b.js'), 'utf8')).toBe('two');
+  });
+
+  it('singleCode skips code files, writes README only', () => {
+    const bundle = makeBundle({
+      tutorial: { tutorialMode: 'singleCode' },
+      pages: [{ pageNumber: 1, markdown: 'md', codeObjects: [{ title: 'shouldnot.js', code: 'x' }] }],
+    });
+    writeTutorial(bundle, dir, { sketchId: 1 }, {});
+    expect(fs.existsSync(path.join(dir, 'tutorial/page_1/README.md'))).toBe(true);
+    expect(fs.existsSync(path.join(dir, 'tutorial/page_1/shouldnot.js'))).toBe(false);
+  });
+
+  it('saveMetadata: false skips tutorial.json', () => {
+    writeTutorial(makeBundle(), dir, { sketchId: 1 }, { saveMetadata: false });
+    expect(fs.existsSync(path.join(dir, 'metadata/tutorial.json'))).toBe(false);
+  });
+
+  it('saveMetadata: true writes tutorial.json verbatim with failedPages', () => {
+    const bundle = makeBundle({
+      failedPages: [{ pageNumber: 3, error: Object.assign(new Error('boom'), { status: 500 }) }],
+    });
+    writeTutorial(bundle, dir, { sketchId: 1 }, { saveMetadata: true, quiet: true });
+    const raw = JSON.parse(fs.readFileSync(path.join(dir, 'metadata/tutorial.json'), 'utf8'));
+    expect(raw.tutorialMode).toBe('normal');
+    expect(raw.totalPages).toBe(2);
+    expect(raw.failedPages).toEqual([{ pageNumber: 3, error: 'boom', status: 500 }]);
+  });
+
+  it('path-traversal regression: codeObjects title stays inside page_N', () => {
+    const bundle = makeBundle({
+      pages: [{
+        pageNumber: 1,
+        markdown: '',
+        codeObjects: [{ title: '../../etc/passwd', code: 'x' }],
+      }],
+      tutorial: { tutorialMode: 'normal', totalPages: 1 },
+    });
+    writeTutorial(bundle, dir, { sketchId: 1 }, {});
+    const pageDir = path.join(dir, 'tutorial/page_1');
+    const entries = fs.readdirSync(pageDir);
+    expect(entries).toContain('README.md');
+    // No directory escape happened.
+    expect(fs.existsSync(path.join(dir, '..', '..', 'etc', 'passwd'))).toBe(false);
+    // All entries live under pageDir.
+    for (const e of entries) {
+      expect(path.resolve(pageDir, e).startsWith(path.resolve(pageDir))).toBe(true);
+    }
+  });
+
+  it('collision: two codeObjects with same sanitized name -> second is _2', () => {
+    const bundle = makeBundle({
+      pages: [{
+        pageNumber: 1,
+        markdown: '',
+        codeObjects: [
+          { title: 'dup.js', code: 'a' },
+          { title: 'dup.js', code: 'b' },
+        ],
+      }],
+      tutorial: { tutorialMode: 'normal', totalPages: 1 },
+    });
+    writeTutorial(bundle, dir, { sketchId: 1 }, {});
+    expect(fs.readFileSync(path.join(dir, 'tutorial/page_1/dup.js'), 'utf8')).toBe('a');
+    expect(fs.readFileSync(path.join(dir, 'tutorial/page_1/dup_2.js'), 'utf8')).toBe('b');
+  });
+
+  it('failedPages > 0: warns and still writes successful pages', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const bundle = makeBundle({
+      failedPages: [{ pageNumber: 5, error: new Error('nope') }],
+    });
+    writeTutorial(bundle, dir, { sketchId: 1 }, {});
+    expect(fs.existsSync(path.join(dir, 'tutorial/page_1/README.md'))).toBe(true);
+    expect(warnSpy).toHaveBeenCalled();
+    const message = warnSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+    expect(message).toMatch(/5/);
+  });
+
+  it('empty markdown still writes an empty README.md', () => {
+    const bundle = makeBundle({
+      pages: [{ pageNumber: 1, markdown: '', codeObjects: [] }],
+      tutorial: { tutorialMode: 'singleCode', totalPages: 1 },
+    });
+    writeTutorial(bundle, dir, { sketchId: 1 }, {});
+    const md = fs.readFileSync(path.join(dir, 'tutorial/page_1/README.md'), 'utf8');
+    expect(md).toBe('');
+  });
+});

--- a/tests/index.test.mjs
+++ b/tests/index.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import nock from 'nock';
@@ -567,4 +567,54 @@ describe('opdl (integration)', () => {
     expect(tutorialMeta.tutorialMode).toBe('normal');
     expect(tutorialMeta.failedPages).toEqual([]);
   });
+
+  it('logs tutorial 429 retry warning when verbose: true reaches fetcher', async () => {
+    // Regression: previously opdl() dropped `verbose` when calling fetchSketchInfo,
+    // so this warning never fired on the CLI/programmatic path even on 429s.
+    const sketchId = 2798402;
+
+    nock('https://openprocessing.org')
+      .get(`/api/sketch/${sketchId}`)
+      .reply(200, {
+        visualID: sketchId, title: 'T', mode: 'p5js', userID: 7, tutorialMode: 1,
+      });
+    nock('https://openprocessing.org').get('/api/user/7').reply(200, { fullname: 'A' });
+    nock('https://openprocessing.org')
+      .get(`/api/sketch/${sketchId}/code`)
+      .reply(200, [{ title: 'sketch.js', code: '' }]);
+    nock('https://openprocessing.org')
+      .get(`/api/sketch/${sketchId}/files?limit=100&offset=0`).reply(200, []);
+    nock('https://openprocessing.org')
+      .get(`/api/sketch/${sketchId}/libraries?limit=100&offset=0`).reply(200, []);
+    nock('https://openprocessing.org')
+      .get(`/api/tutorial/${sketchId}`)
+      .reply(200, { visualID: sketchId, totalPages: 1, tutorialMode: 'normal' });
+    // 429 on first attempt, 200 on retry.
+    nock('https://openprocessing.org')
+      .get(`/api/tutorial/${sketchId}/page/1/`)
+      .reply(429, { message: 'Too Many Requests' });
+    nock('https://openprocessing.org')
+      .get(`/api/tutorial/${sketchId}/page/1/`)
+      .reply(200, { markdown: '# ok', codeObjects: [] });
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const result = await opdl(sketchId, {
+        outputDir: testDir,
+        downloadAssets: false,
+        downloadThumbnail: false,
+        saveMetadata: false,
+        addSourceComments: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        quiet: false,
+        verbose: true,
+      });
+      expect(result.success).toBe(true);
+      const messages = warnSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(messages).toMatch(/tutorial page 1 hit 429/);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  }, 10000);
 });

--- a/tests/index.test.mjs
+++ b/tests/index.test.mjs
@@ -492,4 +492,79 @@ describe('opdl (integration)', () => {
     const codeContent = fs.readFileSync(path.join(testDir, 'sketch.js'), 'utf8');
     expect(codeContent).not.toContain('Downloaded with opdl');
   });
+
+  it('downloads tutorial bundle end-to-end (tutorial/ + metadata/tutorial.json)', async () => {
+    const sketchId = 2798401;
+
+    nock('https://openprocessing.org')
+      .get(`/api/sketch/${sketchId}`)
+      .reply(200, {
+        visualID: sketchId,
+        title: 'Tut Sketch',
+        mode: 'p5js',
+        userID: 7,
+        license: 'by',
+        engineURL: 'https://cdn.com/p5.js',
+        tutorialMode: 1,
+      });
+
+    nock('https://openprocessing.org')
+      .get('/api/user/7')
+      .reply(200, { fullname: 'Tut Author' });
+
+    nock('https://openprocessing.org')
+      .get(`/api/sketch/${sketchId}/code`)
+      .reply(200, [{ title: 'sketch.js', code: 'function setup() {}' }]);
+
+    nock('https://openprocessing.org')
+      .get(`/api/sketch/${sketchId}/files?limit=100&offset=0`)
+      .reply(200, []);
+
+    nock('https://openprocessing.org')
+      .get(`/api/sketch/${sketchId}/libraries?limit=100&offset=0`)
+      .reply(200, []);
+
+    nock('https://openprocessing.org')
+      .get(`/api/tutorial/${sketchId}`)
+      .reply(200, {
+        visualID: sketchId,
+        tutorialID: 123,
+        totalPages: 2,
+        tutorialMode: 'normal',
+      });
+
+    nock('https://openprocessing.org')
+      .get(`/api/tutorial/${sketchId}/page/1/`)
+      .reply(200, { markdown: '# Page 1', codeObjects: [] });
+
+    nock('https://openprocessing.org')
+      .get(`/api/tutorial/${sketchId}/page/2/`)
+      .reply(200, {
+        markdown: '# Page 2',
+        codeObjects: [{ title: 'mySketch', code: 'function setup(){}' }],
+      });
+
+    const result = await opdl(sketchId, {
+      outputDir: testDir,
+      downloadAssets: false,
+      downloadThumbnail: false,
+      saveMetadata: true,
+      addSourceComments: false,
+      createLicenseFile: false,
+      createOpMetadata: false,
+      quiet: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(fs.existsSync(path.join(testDir, 'tutorial/page_1/README.md'))).toBe(true);
+    expect(fs.existsSync(path.join(testDir, 'tutorial/page_2/README.md'))).toBe(true);
+    expect(fs.existsSync(path.join(testDir, 'tutorial/page_2/mySketch.js'))).toBe(true);
+
+    const tutorialMeta = JSON.parse(
+      fs.readFileSync(path.join(testDir, 'metadata/tutorial.json'), 'utf8')
+    );
+    expect(tutorialMeta.totalPages).toBe(2);
+    expect(tutorialMeta.tutorialMode).toBe('normal');
+    expect(tutorialMeta.failedPages).toEqual([]);
+  });
 });


### PR DESCRIPTION
Fixes #25

This pull request adds support for downloading and saving OpenProcessing tutorials, including fetching tutorial metadata and pages, handling retries for rate limits, and writing tutorial content (including code files and markdown) to disk. It also updates type definitions and field descriptions to accommodate the new tutorial data structures and tutorial modes.

**Tutorial Fetching & Download:**
* Added `fetchTutorialBundle`, `httpGetViaClient`, `httpGetViaAxios`, and `isTutorialMode` utilities in `tutorialFetcher.js` to fetch tutorial metadata and all pages, with retry logic for rate limits and support for both API and CLI flows.
* Integrated tutorial fetching into the main download pipeline (`service.js` and `fetcher.js`), so that if a sketch is a tutorial, its metadata and pages are fetched and attached to `sketchInfo`. Errors are handled gracefully. [[1]](diffhunk://#diff-3f11199b0f7c69d987598ebab732c3e8bf64014feff563b02557b257c3c15911R129-R145) [[2]](diffhunk://#diff-50c7b7e1dfc86b77e3347459fd71693e59622598a76f05887e37df20d37559a3R189-R202)
* Added `writeTutorial` in `tutorialWriter.js` to save tutorial metadata and pages (markdown and code files) into a `tutorial/` subdirectory, including error reporting for failed pages.
* Updated the main downloader (`downloader.js`) to call `writeTutorial` after the main sketch is downloaded, if tutorial data is present.

**Code File Handling:**
* Refactored code file writing into a reusable `writeCodeFile` utility, which deduplicates filenames, ensures safe naming, adds attribution comments, and is used for both sketch and tutorial code files. [[1]](diffhunk://#diff-101399b9d9784cb3e26a1f4e313340cd6ed8bf4d5b190b846c2cfce1bd71bc31R1-R75) [[2]](diffhunk://#diff-ce30c6fea1c73bb064343945c0f8951333a47c41df34ace1187c439af844e3b0R28-R41)

**Type & Field Updates:**
* Updated type definitions in `types.js` and `types/api.js` to support new tutorial structures (`TutorialPage`, `TutorialBundle`) and to clarify the possible values for `tutorialMode` (now supports both numeric and string values). [[1]](diffhunk://#diff-b0353f6a4925a10f0a706517b40cf49e574f050743298c562ad3a02f1086ee8cL26-R26) [[2]](diffhunk://#diff-b0353f6a4925a10f0a706517b40cf49e574f050743298c562ad3a02f1086ee8cR176-R189) [[3]](diffhunk://#diff-fad7f5dce377420a5c6d24bb0fdd987f5bc1f0ad834eb1498dc02232baee6d48R32-R37)
* Updated CLI field registry to reflect the new `tutorialMode` type and description.