### PR TITLE
Handle code/upload filename conflicts

### DIFF
--- a/src/download/codeFileWriter.js
+++ b/src/download/codeFileWriter.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 
-const { sanitizeFilename, rewriteAssetReferences } = require('../utils');
+const { sanitizeFilename, rewriteAssetReferences, dedupeFilename } = require('../utils');
 const { buildCommentBlock } = require('./codeAttributor');
 
 /**
@@ -48,17 +48,7 @@ function writeCodeFile({
   fileExtension = path.extname(codeFileName) || '.js';
 
   // De-dup within outputDir.
-  if (usedNames.has(codeFileName)) {
-    const ext = path.extname(codeFileName);
-    const base = codeFileName.slice(0, codeFileName.length - ext.length);
-    let suffix = 2;
-    let candidate = `${base}_${suffix}${ext}`;
-    while (usedNames.has(candidate)) {
-      suffix += 1;
-      candidate = `${base}_${suffix}${ext}`;
-    }
-    codeFileName = candidate;
-  }
+  codeFileName = dedupeFilename(codeFileName, usedNames);
   usedNames.add(codeFileName);
 
   const codeFilePath = path.join(outputDir, codeFileName);

--- a/src/download/curationDownloader.js
+++ b/src/download/curationDownloader.js
@@ -4,6 +4,7 @@ const opdl = require('../index');
 const { sanitizeFilename } = require('../utils');
 const { scaffoldGalleryProject } = require('./galleryScaffolder');
 const { promptConflictAction } = require('./conflictPrompt');
+const { promptFilenameConflictAction } = require('./filenameConflictPrompt');
 
 const RETRY_DELAYS = [1000, 2000];
 const sleepDefault = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -51,7 +52,8 @@ function galleryYaml() {
 
 async function downloadCuration({
   curationId, client, opdlFn = opdl, scaffoldFn = scaffoldGalleryProject,
-  onConflict = promptConflictAction, options = {}, sleep = sleepDefault,
+  onConflict = promptConflictAction, onFilenameConflict = promptFilenameConflictAction,
+  options = {}, sleep = sleepDefault,
 }) {
   const curation = await client.getCuration(curationId);
   const limit = Number.isFinite(options.limit) ? options.limit : undefined;
@@ -69,6 +71,22 @@ async function downloadCuration({
   // (or forces a policy up front with --skipExisting / --overwrite).
   let conflictPolicy = options.overwrite ? 'overwrite' : (options.skipExisting ? 'skip' : null);
   let cancelled = false;
+
+  // Policy for uploaded-file-vs-code-object name collisions (see
+  // filenameConflictPrompt). Prompt once, then apply to the rest of the run.
+  // Passed into each downloadSketch call so the collision — detected inside
+  // downloadSketch — is resolved by this shared, batch-aware handler rather
+  // than downloadSketch's own per-sketch prompt.
+  let filenamePolicy = null;
+  const curationFilenameConflict = async ({ filename }) => {
+    if (filenamePolicy) return filenamePolicy;
+    const action = await onFilenameConflict({ filename, quiet: options.quiet, batch: true });
+    if (action.endsWith('-all')) {
+      filenamePolicy = action.slice(0, -'-all'.length);
+      return filenamePolicy;
+    }
+    return action;
+  };
 
   for (let index = 0; index < sketches.length; index += 1) {
     const sketch = sketches[index];
@@ -110,6 +128,7 @@ async function downloadCuration({
           createOpMetadata: options.createOpMetadata !== false,
           verbose: options.verbose || false,
           token: options.token,
+          onFilenameConflict: curationFilenameConflict,
           vite: false, run: false, quiet: true,
         });
         if (!result?.success) {

--- a/src/download/downloader.js
+++ b/src/download/downloader.js
@@ -7,12 +7,14 @@ const {
   sanitizeFilename,
   buildAssetRenameMap,
   resolveAssetUrl,
+  dedupeFilename,
 } = require('../utils');
 const { generateIndexHtml } = require('./htmlGenerator');
 const { createLicenseFile } = require('./licenseHandler');
 const { createOpMetadata } = require('./metadataWriter');
 const { writeCodeFile } = require('./codeFileWriter');
 const { writeTutorial } = require('./tutorialWriter');
+const { promptFilenameConflictAction } = require('./filenameConflictPrompt');
 
 const META_DIR = 'metadata';
 const THUMBNAIL_URL_TEMPLATE = 'https://kyoko.openprocessing.org/thumbnails/visualThumbnail{visualID}@2x.jpg';
@@ -26,6 +28,7 @@ const downloadSketch = async (sketchInfo, options = {}) => {
 
   ensureDirectoryExists(outputDir);
   const shouldAddSourceComments = finalOptions.addSourceComments;
+  const onFilenameConflict = finalOptions.onFilenameConflict || promptFilenameConflictAction;
 
   const savedCodeFiles = [];
   const sanitizedCodeParts = [];
@@ -70,6 +73,28 @@ const downloadSketch = async (sketchInfo, options = {}) => {
           continue;
         }
 
+        let assetFileName = sanitizeFilename(filename) || path.basename(filename);
+        // A sketch's uploaded files can collide with an authoritative code
+        // object of the same name — e.g. a stale index.html left over from an
+        // older version that points at files no longer present. Writing it
+        // blindly clobbers the code object (causing 404s at runtime), so we
+        // surface the conflict and let the user decide.
+        if (rootUsedNames.has(assetFileName)) {
+          const action = await onFilenameConflict({
+            filename: assetFileName,
+            quiet: finalOptions.quiet,
+          });
+          if (action === 'skip-upload') {
+            continue;
+          }
+          if (action === 'keep-both') {
+            // Code object keeps its canonical name; rename the uploaded file.
+            assetFileName = dedupeFilename(assetFileName, rootUsedNames);
+          }
+          // 'overwrite-code' falls through and reuses the canonical name.
+        }
+        rootUsedNames.add(assetFileName);
+
         const assetUrl = resolveAssetUrl(assetBaseUrl, filename);
         if (!assetUrl) {
           if (!finalOptions.quiet) {
@@ -83,7 +108,6 @@ const downloadSketch = async (sketchInfo, options = {}) => {
             console.log(`opdl: downloading asset ${filename} from ${assetUrl}`);
           }
           const response = await axios.get(assetUrl, { responseType: 'arraybuffer' });
-          const assetFileName = sanitizeFilename(filename) || path.basename(filename);
           const assetFilePath = path.join(outputDir, assetFileName);
           fs.writeFileSync(assetFilePath, response.data);
         } catch (error) {

--- a/src/download/filenameConflictPrompt.js
+++ b/src/download/filenameConflictPrompt.js
@@ -1,0 +1,75 @@
+const prompts = require('prompts');
+
+const CONFLICT_CHOICES = [
+  { title: 'Keep both (rename the uploaded file)', value: 'keep-both' },
+  { title: 'Keep the code object (skip the uploaded file)', value: 'skip-upload' },
+  { title: 'Overwrite the code object with the uploaded file', value: 'overwrite-code' },
+];
+
+// During a curation download the same collision can recur across many
+// sketches. These "…for all remaining" variants let the user answer once and
+// have that decision applied to the rest of the run (mirrors conflictPrompt's
+// skip-all / overwrite-all).
+const BATCH_CONFLICT_CHOICES = [
+  { title: 'Keep both (rename the uploaded file)', value: 'keep-both' },
+  { title: 'Keep the code object (skip the uploaded file)', value: 'skip-upload' },
+  { title: 'Overwrite the code object with the uploaded file', value: 'overwrite-code' },
+  { title: 'Keep both for all remaining collisions', value: 'keep-both-all' },
+  { title: 'Keep the code object for all remaining collisions', value: 'skip-upload-all' },
+  { title: 'Overwrite the code object for all remaining collisions', value: 'overwrite-code-all' },
+];
+
+/**
+ * Ask what to do when an uploaded file shares a name with a code object.
+ *
+ * A sketch's uploaded files can include a leftover (e.g. an old index.html)
+ * that collides with the authoritative code-object file of the same name.
+ * Writing it blindly clobbers the code object; skipping it silently hides the
+ * conflict. So we surface it and let the user decide.
+ *
+ * Non-interactive sessions (no TTY, or --quiet — which is how curation batch
+ * downloads always run) default to 'keep-both': nothing is lost and the
+ * code object keeps its canonical name.
+ *
+ * @param {Object} params
+ * @param {string} params.filename - The colliding filename (e.g. 'index.html')
+ * @param {boolean} [params.quiet] - Suppress prompting (unattended runs)
+ * @param {boolean} [params.batch] - Offer "…for all remaining" choices too
+ *   (used by curation downloads so the user can decide the policy once)
+ * @param {boolean} [params.isInteractive] - Override TTY detection (for tests)
+ * @param {Function} [params.promptFn] - Prompt implementation (for tests)
+ * @returns {Promise<'keep-both'|'skip-upload'|'overwrite-code'|
+ *   'keep-both-all'|'skip-upload-all'|'overwrite-code-all'>}
+ */
+async function promptFilenameConflictAction({
+  filename,
+  quiet = false,
+  batch = false,
+  isInteractive = Boolean(process.stdin.isTTY && process.stdout.isTTY),
+  promptFn = prompts,
+} = {}) {
+  if (quiet || !isInteractive) {
+    if (!quiet) {
+      console.warn(
+        `opdl: WARNING — "${filename}" exists as both a code object and an uploaded file. ` +
+          'Keeping the code object; the uploaded file will be saved under a different name.'
+      );
+    }
+    return batch ? 'keep-both-all' : 'keep-both';
+  }
+  console.warn(
+    `opdl: WARNING — "${filename}" exists as both a code object and an uploaded file.`
+  );
+  const response = await promptFn({
+    type: 'select',
+    name: 'action',
+    message: 'What would you like to do?',
+    choices: batch ? BATCH_CONFLICT_CHOICES : CONFLICT_CHOICES,
+    initial: 0,
+  });
+  // prompts resolves with no answer when the user aborts (Ctrl+C/Esc);
+  // fall back to the safe default that loses nothing.
+  return response?.action || 'keep-both';
+}
+
+module.exports = { promptFilenameConflictAction, CONFLICT_CHOICES, BATCH_CONFLICT_CHOICES };

--- a/src/download/filenameConflictPrompt.js
+++ b/src/download/filenameConflictPrompt.js
@@ -27,9 +27,9 @@ const BATCH_CONFLICT_CHOICES = [
  * Writing it blindly clobbers the code object; skipping it silently hides the
  * conflict. So we surface it and let the user decide.
  *
- * Non-interactive sessions (no TTY, or --quiet — which is how curation batch
- * downloads always run) default to 'keep-both': nothing is lost and the
- * code object keeps its canonical name.
+ * Non-interactive sessions (no TTY) default to 'keep-both': nothing is lost and
+ * the code object keeps its canonical name. When `--quiet` is set, prompting is
+ * suppressed (unattended runs) and the same safe default is used.
  *
  * @param {Object} params
  * @param {string} params.filename - The colliding filename (e.g. 'index.html')

--- a/src/utils.js
+++ b/src/utils.js
@@ -109,10 +109,33 @@ const resolveAssetUrl = (assetBaseUrl, filename) => {
   return '';
 };
 
+/**
+ * Return a filename not already present in `usedNames`, appending _2, _3, …
+ * before the extension until it is unique. Does not mutate `usedNames`.
+ * @param {string} filename - Desired filename (may already be taken)
+ * @param {Set<string>} usedNames - Names already claimed in the target directory
+ * @returns {string} A filename absent from usedNames
+ */
+const dedupeFilename = (filename, usedNames) => {
+  if (!usedNames.has(filename)) {
+    return filename;
+  }
+  const ext = path.extname(filename);
+  const base = filename.slice(0, filename.length - ext.length);
+  let suffix = 2;
+  let candidate = `${base}_${suffix}${ext}`;
+  while (usedNames.has(candidate)) {
+    suffix += 1;
+    candidate = `${base}_${suffix}${ext}`;
+  }
+  return candidate;
+};
+
 module.exports = {
   ensureDirectoryExists,
   sanitizeFilename,
   buildAssetRenameMap,
   rewriteAssetReferences,
   resolveAssetUrl,
+  dedupeFilename,
 };

--- a/tests/download/curationDownloader.test.mjs
+++ b/tests/download/curationDownloader.test.mjs
@@ -95,6 +95,55 @@ describe('downloadCuration', () => {
     }
   });
 
+  it('prompts once for a filename collision and applies the -all policy to the rest', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-curation-'));
+    try {
+      // Simulate downloadSketch detecting an index.html collision on every
+      // sketch: it consults the injected handler and records what it resolved to.
+      const resolved = [];
+      const opdlFn = vi.fn(async (id, opts) => {
+        const action = await opts.onFilenameConflict({ filename: 'index.html' });
+        resolved.push(action);
+        return { success: true, sketchInfo: { visualID: id, title: `S${id}` } };
+      });
+      const onFilenameConflict = vi.fn().mockResolvedValue('keep-both-all');
+
+      const result = await downloadCuration({
+        curationId: 9,
+        client: conflictClient([{ visualID: 1, title: 'A' }, { visualID: 2, title: 'B' }, { visualID: 3, title: 'C' }]),
+        opdlFn, scaffoldFn: vi.fn(), onFilenameConflict,
+        options: { outputDir: root, quiet: true },
+      });
+
+      // Asked once; the -all suffix is stripped so downloadSketch sees a base action.
+      expect(onFilenameConflict).toHaveBeenCalledTimes(1);
+      expect(onFilenameConflict.mock.calls[0][0]).toMatchObject({ filename: 'index.html', batch: true, quiet: true });
+      expect(resolved).toEqual(['keep-both', 'keep-both', 'keep-both']);
+      expect(result.manifest).toHaveLength(3);
+    } finally { fs.rmSync(root, { recursive: true, force: true }); }
+  });
+
+  it('re-prompts each time when the filename choice is not an -all variant', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-curation-'));
+    try {
+      const opdlFn = vi.fn(async (id, opts) => {
+        await opts.onFilenameConflict({ filename: 'index.html' });
+        return { success: true, sketchInfo: { visualID: id, title: `S${id}` } };
+      });
+      const onFilenameConflict = vi.fn().mockResolvedValue('skip-upload');
+
+      await downloadCuration({
+        curationId: 9,
+        client: conflictClient([{ visualID: 1, title: 'A' }, { visualID: 2, title: 'B' }]),
+        opdlFn, scaffoldFn: vi.fn(), onFilenameConflict,
+        options: { outputDir: root, quiet: true },
+      });
+
+      // No policy locked in, so each colliding sketch prompts again.
+      expect(onFilenameConflict).toHaveBeenCalledTimes(2);
+    } finally { fs.rmSync(root, { recursive: true, force: true }); }
+  });
+
   it('cancel stops the download without scaffolding or writing the manifest', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-curation-'));
     try {

--- a/tests/download/downloader.test.mjs
+++ b/tests/download/downloader.test.mjs
@@ -199,6 +199,94 @@ describe('downloader', () => {
       expect(fs.existsSync(path.join(testDir, 'image.png'))).toBe(true);
     });
 
+    describe('uploaded file vs code object name collision', () => {
+      const codeHtml = '<script src="mySketch.js"></script>';
+      const uploadHtml = '<script src="sketch.js"></script>';
+
+      const makeSketchInfo = () => ({
+        sketchId: 12345,
+        title: 'Test',
+        author: 'Author',
+        codeParts: [
+          { title: 'index.html', code: codeHtml },
+          { title: 'mySketch.js', code: 'console.log("test");' },
+        ],
+        files: [{ name: 'index.html' }],
+        metadata: { mode: 'html', fileBase: 'https://example.com/assets' },
+      });
+
+      const baseOptions = {
+        outputDir: testDir,
+        downloadAssets: true,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: false,
+      };
+
+      it('keeps both by renaming the uploaded file (default)', async () => {
+        nock('https://example.com').get('/assets/index.html').reply(200, uploadHtml);
+
+        await downloadSketch(makeSketchInfo(), {
+          ...baseOptions,
+          onFilenameConflict: async () => 'keep-both',
+        });
+
+        // Code object keeps the canonical name; upload lands under index_2.html.
+        expect(fs.readFileSync(path.join(testDir, 'index.html'), 'utf8')).toBe(codeHtml);
+        expect(fs.readFileSync(path.join(testDir, 'index_2.html'), 'utf8')).toBe(uploadHtml);
+      });
+
+      it('skips the uploaded file when asked', async () => {
+        const upload = nock('https://example.com')
+          .get('/assets/index.html')
+          .reply(200, uploadHtml);
+
+        await downloadSketch(makeSketchInfo(), {
+          ...baseOptions,
+          onFilenameConflict: async () => 'skip-upload',
+        });
+
+        expect(fs.readFileSync(path.join(testDir, 'index.html'), 'utf8')).toBe(codeHtml);
+        expect(fs.existsSync(path.join(testDir, 'index_2.html'))).toBe(false);
+        // Skipped before fetching.
+        expect(upload.isDone()).toBe(false);
+        nock.cleanAll();
+      });
+
+      it('overwrites the code object when asked', async () => {
+        nock('https://example.com').get('/assets/index.html').reply(200, uploadHtml);
+
+        await downloadSketch(makeSketchInfo(), {
+          ...baseOptions,
+          onFilenameConflict: async () => 'overwrite-code',
+        });
+
+        expect(fs.readFileSync(path.join(testDir, 'index.html'), 'utf8')).toBe(uploadHtml);
+        expect(fs.existsSync(path.join(testDir, 'index_2.html'))).toBe(false);
+      });
+
+      it('is not triggered when names do not collide', async () => {
+        let called = false;
+        nock('https://example.com').get('/assets/data.json').reply(200, '{}');
+
+        const info = makeSketchInfo();
+        info.files = [{ name: 'data.json' }];
+
+        await downloadSketch(info, {
+          ...baseOptions,
+          onFilenameConflict: async () => {
+            called = true;
+            return 'keep-both';
+          },
+        });
+
+        expect(called).toBe(false);
+        expect(fs.existsSync(path.join(testDir, 'data.json'))).toBe(true);
+      });
+    });
+
     it('should skip assets when downloadAssets is false', async () => {
       const sketchInfo = {
         sketchId: 12345,

--- a/tests/download/filenameConflictPrompt.test.mjs
+++ b/tests/download/filenameConflictPrompt.test.mjs
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { promptFilenameConflictAction, CONFLICT_CHOICES, BATCH_CONFLICT_CHOICES } from '../../src/download/filenameConflictPrompt.js';
+
+describe('promptFilenameConflictAction', () => {
+  it('shows a select prompt defaulting to keep-both and returns the chosen action', async () => {
+    const promptFn = vi.fn().mockResolvedValue({ action: 'overwrite-code' });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const action = await promptFilenameConflictAction({ filename: 'index.html', isInteractive: true, promptFn });
+      expect(action).toBe('overwrite-code');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('"index.html"'));
+      const question = promptFn.mock.calls[0][0];
+      expect(question).toMatchObject({ type: 'select', name: 'action', initial: 0 });
+      expect(question.choices).toBe(CONFLICT_CHOICES);
+      expect(question.choices[0]).toMatchObject({ value: 'keep-both' });
+      expect(question.choices.map((choice) => choice.value)).toEqual(['keep-both', 'skip-upload', 'overwrite-code']);
+    } finally { warnSpy.mockRestore(); }
+  });
+
+  it('treats an aborted prompt (Ctrl+C) as keep-both', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const action = await promptFilenameConflictAction({ filename: 'index.html', isInteractive: true, promptFn: vi.fn().mockResolvedValue({}) });
+      expect(action).toBe('keep-both');
+    } finally { warnSpy.mockRestore(); }
+  });
+
+  it('offers the "…for all remaining" choices in batch mode', async () => {
+    const promptFn = vi.fn().mockResolvedValue({ action: 'keep-both-all' });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const action = await promptFilenameConflictAction({ filename: 'index.html', batch: true, isInteractive: true, promptFn });
+      expect(action).toBe('keep-both-all');
+      const question = promptFn.mock.calls[0][0];
+      expect(question.choices).toBe(BATCH_CONFLICT_CHOICES);
+      expect(question.choices.map((choice) => choice.value)).toEqual([
+        'keep-both', 'skip-upload', 'overwrite-code',
+        'keep-both-all', 'skip-upload-all', 'overwrite-code-all',
+      ]);
+    } finally { warnSpy.mockRestore(); }
+  });
+
+  it('defaults to keep-both-all in batch mode when non-interactive', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(await promptFilenameConflictAction({ filename: 'index.html', batch: true, isInteractive: false, promptFn: vi.fn() })).toBe('keep-both-all');
+    } finally { warnSpy.mockRestore(); }
+  });
+
+  it('defaults to keep-both without prompting when the session is non-interactive', async () => {
+    const promptFn = vi.fn();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(await promptFilenameConflictAction({ filename: 'index.html', isInteractive: false, promptFn })).toBe('keep-both');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      // --quiet suppresses even the warning and does not prompt.
+      expect(await promptFilenameConflictAction({ filename: 'index.html', quiet: true, isInteractive: true, promptFn })).toBe('keep-both');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(promptFn).not.toHaveBeenCalled();
+    } finally { warnSpy.mockRestore(); }
+  });
+});


### PR DESCRIPTION
Add explicit conflict handling when an uploaded asset has the same sanitized name as a code object (e.g., index.html in sketch [2317762](https://openprocessing.org/@u454346/2317762)), with actions to keep both, skip upload, or overwrite code. Introduce a shared filename deduplication utility, add an interactive/non-interactive conflict prompt module (including batch “for all” behavior for curation downloads), and expand downloader/curation tests to cover the new collision flows.

<img width="664" height="207" alt="image" src="https://github.com/user-attachments/assets/eb8fec82-5eb9-406a-89d8-331634f88b5c" />
