### PR TITLE
Only add attribution comment to js and html files

### DIFF
--- a/src/download/codeAttributor.js
+++ b/src/download/codeAttributor.js
@@ -31,10 +31,12 @@ const buildCommentBlock = (sketchInfo, fileExtension = '') => {
   const licenseDisplay = getLicenseDisplay(sketchInfo.metadata?.license);
   const sourceUrl = `https://openprocessing.org/sketch/${sketchInfo.sketchId}`;
 
-  // Determine comment style based on file extension
-  const isHtml = fileExtension === '.html' || fileExtension === '.htm';
-  const isPython = fileExtension === '.py';
-  const isShell = fileExtension === '.sh' || fileExtension === '.bash';
+  // Determine comment style based on file extension (case-insensitive to match
+  // shouldAddAttribution, e.g. an `.HTML` file must still get an HTML comment).
+  const ext = fileExtension.toLowerCase();
+  const isHtml = ext === '.html' || ext === '.htm';
+  const isPython = ext === '.py';
+  const isShell = ext === '.sh' || ext === '.bash';
 
   let lines;
 

--- a/src/download/codeAttributor.js
+++ b/src/download/codeAttributor.js
@@ -17,6 +17,14 @@ const getLicenseDisplay = (licenseCode) => {
   return LICENSE_NAMES[licenseCode] || licenseCode;
 };
 
+// Only prepend attribution to file types where a leading comment is always safe.
+// Notably shaders are excluded: GLSL requires the `#version` directive on the very
+// first line, so a prepended comment block breaks compilation.
+const ATTRIBUTION_EXTENSIONS = new Set(['.js', '.html', '.htm']);
+
+const shouldAddAttribution = (fileExtension = '') =>
+  ATTRIBUTION_EXTENSIONS.has(fileExtension.toLowerCase());
+
 const buildCommentBlock = (sketchInfo, fileExtension = '') => {
   const title = sketchInfo.title || sketchInfo.metadata?.title || 'Untitled';
   const author = sketchInfo.author || sketchInfo.metadata?.fullname || 'Unknown';
@@ -120,6 +128,9 @@ const addSourceComments = (sketchInfo, codeFilePaths = [], options = {}) => {
         continue;
       }
       const fileExtension = path.extname(normalizedPath);
+      if (!shouldAddAttribution(fileExtension)) {
+        continue;
+      }
       const commentBlock = buildCommentBlock(sketchInfo, fileExtension);
       fs.writeFileSync(normalizedPath, `${commentBlock}${content.startsWith('\n') ? '' : '\n'}${content}`, 'utf8');
     } catch (error) {
@@ -130,4 +141,4 @@ const addSourceComments = (sketchInfo, codeFilePaths = [], options = {}) => {
   }
 };
 
-module.exports = { buildCommentBlock };
+module.exports = { buildCommentBlock, shouldAddAttribution };

--- a/src/download/codeFileWriter.js
+++ b/src/download/codeFileWriter.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 const { sanitizeFilename, rewriteAssetReferences, dedupeFilename } = require('../utils');
-const { buildCommentBlock } = require('./codeAttributor');
+const { buildCommentBlock, shouldAddAttribution } = require('./codeAttributor');
 
 /**
  * Write a single code block to disk, deduplicating filename collisions inside outputDir.
@@ -54,7 +54,7 @@ function writeCodeFile({
   const codeFilePath = path.join(outputDir, codeFileName);
   const rewrittenCode = rewriteAssetReferences(codeBlock.code || '', assetRenames);
   let fileContent = rewrittenCode;
-  if (addSourceComments && !fileContent.includes('Downloaded with opdl')) {
+  if (addSourceComments && shouldAddAttribution(fileExtension) && !fileContent.includes('Downloaded with opdl')) {
     const commentBlock = buildCommentBlock(sketchInfo, fileExtension);
     fileContent = `${commentBlock}${fileContent.startsWith('\n') ? '' : '\n'}${fileContent}`;
   }

--- a/tests/download/codeAttributor.test.mjs
+++ b/tests/download/codeAttributor.test.mjs
@@ -189,6 +189,21 @@ describe('codeAttributor', () => {
       expect(result).toContain('Downloaded with opdl');
     });
 
+    it('should generate HTML-style comments for uppercase .HTML files', () => {
+      const sketchInfo = {
+        sketchId: 12345,
+        title: 'Test',
+        author: 'Author',
+        metadata: { license: 'by' },
+        isFork: false,
+      };
+
+      const result = buildCommentBlock(sketchInfo, '.HTML');
+
+      expect(result).toMatch(/^<!--/);
+      expect(result.trim()).toMatch(/-->$/);
+    });
+
     it('should generate HTML-style comments for .htm files', () => {
       const sketchInfo = {
         sketchId: 12345,

--- a/tests/download/codeAttributor.test.mjs
+++ b/tests/download/codeAttributor.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildCommentBlock } from '../../src/download/codeAttributor';
+import { buildCommentBlock, shouldAddAttribution } from '../../src/download/codeAttributor';
 
 describe('codeAttributor', () => {
   describe('buildCommentBlock', () => {
@@ -266,6 +266,24 @@ describe('codeAttributor', () => {
 
       expect(result).toMatch(/^\/\*/);
       expect(result.trim()).toMatch(/\*\/$/);
+    });
+  });
+
+  describe('shouldAddAttribution', () => {
+    it('adds attribution for .js, .html, and .htm files', () => {
+      for (const ext of ['.js', '.html', '.htm']) {
+        expect(shouldAddAttribution(ext)).toBe(true);
+      }
+    });
+
+    it('is case-insensitive', () => {
+      expect(shouldAddAttribution('.HTML')).toBe(true);
+    });
+
+    it('does not add attribution to shaders or other file types', () => {
+      for (const ext of ['.glsl', '.vert', '.frag', '.vs', '.fs', '.css', '.py', '.json', '']) {
+        expect(shouldAddAttribution(ext)).toBe(false);
+      }
     });
   });
 });

--- a/tests/download/codeFileWriter.test.mjs
+++ b/tests/download/codeFileWriter.test.mjs
@@ -71,6 +71,21 @@ describe('writeCodeFile', () => {
     expect(content).toMatch(/noop\(\);/);
   });
 
+  it('does not prepend attribution to shader files', () => {
+    const used = new Set();
+    const result = writeCodeFile({
+      outputDir: dir,
+      codeBlock: { title: 'frag.glsl', code: '#version 300 es\nvoid main() {}' },
+      index: 0,
+      sketchInfo: { sketchId: 42, title: 'T', author: 'A' },
+      addSourceComments: true,
+      usedNames: used,
+    });
+    const content = fs.readFileSync(result.codeFilePath, 'utf8');
+    expect(content).not.toMatch(/Downloaded with opdl/);
+    expect(content.startsWith('#version 300 es')).toBe(true);
+  });
+
   it('de-duplicates colliding sanitized names', () => {
     const used = new Set();
     writeCodeFile({


### PR DESCRIPTION
Only prepend attribution to file types where a leading comment is always safe. Notably shaders are excluded: GLSL requires the `#version` directive on the very first line, so a prepended comment block breaks compilation.