### PR TITLE
Add API health command and failure diagnostics

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -9,6 +9,7 @@ Complete command reference and documentation for opdl.
 - [Quick Start](#quick-start)
 - [Authentication](#authentication)
 - [Commands](#commands)
+  - [Diagnostics](#diagnostics)
   - [Field Discovery](#field-discovery)
   - [Sketch Commands](#sketch-commands)
   - [User Commands](#user-commands)
@@ -138,6 +139,31 @@ opdl -h
 ```
 
 Shows usage information and available commands.
+
+### Diagnostics
+
+#### Check API health
+
+```bash
+opdl health
+```
+
+Queries the OpenProcessing API health endpoint and reports its status:
+
+```
+OpenProcessing API: OK
+API version: 23.0.10
+```
+
+Add `--json` for machine-readable output, and `--quiet` to suppress it (the exit
+code is still `0` when healthy and non-zero when the API is degraded or
+unreachable, which is useful in scripts and CI).
+
+opdl also runs this check automatically after an unexpected download failure. If
+the API reports healthy, the failure is likely a bug in opdl or an issue with
+that specific sketch; if it doesn't, the failure is likely an OpenProcessing API
+issue. Expected conditions (a missing, private, or code-hidden sketch) do not
+trigger the automatic check.
 
 ### Field Discovery
 

--- a/bin/opdl.js
+++ b/bin/opdl.js
@@ -10,6 +10,7 @@ const { handleSketchCommand } = require(path.join(__dirname, '..', 'src', 'cli',
 const { handleUserCommand } = require(path.join(__dirname, '..', 'src', 'cli', 'commands', 'user.js'));
 const { handleCurationCommand } = require(path.join(__dirname, '..', 'src', 'cli', 'commands', 'curation.js'));
 const { handleAuthCommand } = require(path.join(__dirname, '..', 'src', 'cli', 'commands', 'auth.js'));
+const { handleHealthCommand } = require(path.join(__dirname, '..', 'src', 'cli', 'commands', 'health.js'));
 const c = require(path.join(__dirname, '..', 'src', 'cli', 'colors.js'));
 
 function isLinkedLocalInstall() {
@@ -67,6 +68,10 @@ async function main() {
         handleAuthCommand(parsed.options);
         break;
 
+      case 'health':
+        await handleHealthCommand({ options: parsed.options });
+        break;
+
       case 'fields':
         await handleFieldsCommand({
           fieldSetName: parsed.id,
@@ -105,8 +110,12 @@ async function main() {
 
     process.exit(0);
   } catch (error) {
-    console.error(`Error: ${error.message}`);
-    process.exit(1);
+    // Handlers that already reported their own status (e.g. `health` printing a
+    // degraded API) set `reported` so we don't tack on a redundant "Error:" line.
+    if (!error.reported) {
+      console.error(`Error: ${error.message}`);
+    }
+    process.exit(error.exitCode || 1);
   }
 }
 
@@ -136,6 +145,9 @@ ${h('COMMANDS:')}
     ${bin('opdl')} ${cmd('auth')} ${flag('--token')} ${arg('<token>')}             Save API token to ~/.opdlrc
     ${bin('opdl')} ${cmd('auth')} ${flag('--clear')}                     Remove saved token
     ${bin('opdl')} ${cmd('auth')}                             Show token status
+
+  ${sub('Diagnostics:')}
+    ${bin('opdl')} ${cmd('health')}                           Check OpenProcessing API status
 
   ${sub('Field Discovery:')}
     ${bin('opdl')} ${cmd('fields')}                           List all available field sets
@@ -202,6 +214,10 @@ ${h('EXAMPLES:')}
   ${dim('opdl user @Sableraph --info fullname,website,createdOn')}
   ${dim('opdl user sketches @Sableraph --limit 10 --info visualID,title')}
   ${dim('opdl user followers @Sableraph --json')}
+
+  ${dim('# Diagnostics')}
+  ${dim('opdl health')}
+  ${dim('opdl health --json')}
 
   ${dim('# Curation operations')}
   ${dim('opdl curation 12 --info title,description')}

--- a/src/api/client.js
+++ b/src/api/client.js
@@ -326,6 +326,29 @@ class OpenProcessingClient {
   }
 
   /**
+   * Check the OpenProcessing API health endpoint.
+   *
+   * Uses `validateStatus: () => true` so a non-2xx status (a down/degraded API)
+   * resolves rather than throws — callers inspect the returned status to decide
+   * how to report it.
+   *
+   * @returns {Promise<{ok: boolean, status: string|null, version: string|null, timestamp: string|null, httpStatus: number, raw: any}>}
+   */
+  async getHealth() {
+    const response = await this.client.get('/api/health', { validateStatus: () => true });
+    const object = response.data?.object || {};
+    const status = object.status ?? null;
+    return {
+      ok: response.status === 200 && response.data?.success === true && status === 'ok',
+      status,
+      version: object.version ?? null,
+      timestamp: object.timestamp ?? null,
+      httpStatus: response.status,
+      raw: response.data,
+    };
+  }
+
+  /**
    * Get popular tags
    * @param {Object} [options] - Tags options
    * @param {number} [options.limit] - Maximum number of results

--- a/src/api/validator.js
+++ b/src/api/validator.js
@@ -28,6 +28,7 @@ const MESSAGES = {
 const API_PATTERNS = {
   HIDDEN_CODE: 'Sketch source code is hidden.',
   PRIVATE_SKETCH: 'private sketch',
+  NOT_FOUND: "doesn't exist",
 };
 
 /**
@@ -74,6 +75,23 @@ const isCodeHidden = (responseData) => {
 };
 
 /**
+ * Check if a response indicates a resource that doesn't exist.
+ * The API returns this as a generic `{ success: false }` envelope, so match on
+ * the message text to classify it as NOT_FOUND rather than a transient error.
+ * @param {*} responseData - API response data
+ * @returns {boolean}
+ */
+const isNotFoundResponse = (responseData) => {
+  if (!responseData || responseData.success !== false) {
+    return false;
+  }
+  return (
+    typeof responseData.message === 'string' &&
+    responseData.message.toLowerCase().includes(API_PATTERNS.NOT_FOUND)
+  );
+};
+
+/**
  * Validate common API response patterns
  * @param {*} responseData - API response data
  * @param {string} resourceType - Type of resource ('sketch', 'user', 'curation')
@@ -113,6 +131,19 @@ const validateResponse = (responseData, resourceType) => {
       valid: false,
       reason: VALIDATION_REASONS.CODE_HIDDEN,
       message: MESSAGES.HIDDEN_CODE,
+      data: responseData,
+      canRetry: false,
+    };
+  }
+
+  // Check for a resource that doesn't exist (returned as a generic error
+  // envelope by the API). Classified as NOT_FOUND so callers don't treat a
+  // plainly-missing resource as a transient/unexpected API failure.
+  if (isNotFoundResponse(responseData)) {
+    return {
+      valid: false,
+      reason: VALIDATION_REASONS.NOT_FOUND,
+      message: responseData.message,
       data: responseData,
       canRetry: false,
     };
@@ -483,6 +514,7 @@ module.exports = {
   // Helper functions
   isPrivateResponse,
   isCodeHidden,
+  isNotFoundResponse,
 
   // Constants
   VALIDATION_REASONS,

--- a/src/cli/commands/health.js
+++ b/src/cli/commands/health.js
@@ -16,8 +16,11 @@ const c = require('../colors');
 async function checkHealth(options = {}) {
   const client = new OpenProcessingClient(getToken(options.token));
   try {
-    const health = await client.getHealth();
-    return { ...health, reachable: true, error: null };
+    // Pick explicit fields rather than spreading — getHealth() also returns
+    // `raw` (the full API envelope, which includes the caller's account id),
+    // and we don't want that leaking into `--json` output.
+    const { ok, status, version, timestamp, httpStatus } = await client.getHealth();
+    return { ok, status, version, timestamp, httpStatus, reachable: true, error: null };
   } catch (error) {
     return {
       ok: false,

--- a/src/cli/commands/health.js
+++ b/src/cli/commands/health.js
@@ -1,0 +1,130 @@
+const { OpenProcessingClient } = require('../../api/client');
+const { getToken } = require('../../config');
+const c = require('../colors');
+
+/**
+ * Query the OpenProcessing API health endpoint.
+ *
+ * Network failures are caught and surfaced as an unreachable result rather than
+ * thrown, so callers (including the automatic post-error check) can report a
+ * clean status instead of crashing.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.token] - Optional bearer token override
+ * @returns {Promise<{ok: boolean, status: string|null, version: string|null, timestamp: string|null, httpStatus: number|null, reachable: boolean, error: string|null}>}
+ */
+async function checkHealth(options = {}) {
+  const client = new OpenProcessingClient(getToken(options.token));
+  try {
+    const health = await client.getHealth();
+    return { ...health, reachable: true, error: null };
+  } catch (error) {
+    return {
+      ok: false,
+      status: null,
+      version: null,
+      timestamp: null,
+      httpStatus: null,
+      reachable: false,
+      error: error?.message || 'Unknown error',
+    };
+  }
+}
+
+/**
+ * Render a health result as human-readable lines.
+ * @param {Awaited<ReturnType<typeof checkHealth>>} health
+ * @returns {string}
+ */
+function formatHealth(health) {
+  if (!health.reachable) {
+    return [
+      `${c.bold('OpenProcessing API')}: ${c.red('unreachable')}`,
+      health.error ? `  ${c.dim(health.error)}` : null,
+    ]
+      .filter(Boolean)
+      .join('\n');
+  }
+
+  const statusLabel = health.ok
+    ? c.green('OK')
+    : c.red(health.status ? health.status : `HTTP ${health.httpStatus}`);
+
+  const lines = [`${c.bold('OpenProcessing API')}: ${statusLabel}`];
+  if (health.version) {
+    lines.push(`API version: ${health.version}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Handle the `opdl health` command.
+ * @param {Object} args
+ * @param {Object} [args.options]
+ */
+async function handleHealthCommand(args = {}) {
+  const options = args.options || {};
+  const health = await checkHealth({ token: options.token });
+
+  if (!options.quiet) {
+    if (options.json) {
+      console.log(JSON.stringify(health, null, 2));
+    } else {
+      console.log(formatHealth(health));
+    }
+  }
+
+  // A degraded or unreachable API is a non-zero exit so scripts can react.
+  if (!health.ok) {
+    const err = new Error(
+      health.reachable
+        ? 'OpenProcessing API is not healthy'
+        : 'OpenProcessing API is unreachable'
+    );
+    err.exitCode = 1;
+    // This command owns its own reporting (or deliberately suppresses it under
+    // --quiet), so the global handler must not tack on an "Error:" line either
+    // way — otherwise --quiet would still leak output.
+    err.reported = true;
+    throw err;
+  }
+}
+
+/**
+ * Run a health check after an unexpected failure and print a short diagnostic
+ * hint to stderr. Never throws — this is a best-effort aid layered on top of an
+ * error that is already being surfaced elsewhere.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.token] - Optional bearer token override
+ * @param {boolean} [options.quiet] - Suppress the diagnostic output
+ */
+async function reportHealthAfterFailure(options = {}) {
+  if (options.quiet) {
+    return;
+  }
+
+  const health = await checkHealth({ token: options.token });
+
+  if (health.ok) {
+    console.error(
+      c.dim(
+        `[opdl] The OpenProcessing API reports healthy (version ${health.version || 'unknown'}), so this looks like a bug in opdl or an issue with this specific sketch. Please report it: https://github.com/SableRaf/opdl/issues`
+      )
+    );
+  } else if (!health.reachable) {
+    console.error(
+      c.yellow(
+        `[opdl] Could not reach the OpenProcessing API (${health.error}). This failure is likely a connectivity or API outage rather than a bug in opdl.`
+      )
+    );
+  } else {
+    console.error(
+      c.yellow(
+        `[opdl] The OpenProcessing API reports as ${health.status || `HTTP ${health.httpStatus}`}. This failure is likely an OpenProcessing API issue rather than a bug in opdl.`
+      )
+    );
+  }
+}
+
+module.exports = { handleHealthCommand, checkHealth, formatHealth, reportHealthAfterFailure };

--- a/src/cli/commands/sketch.js
+++ b/src/cli/commands/sketch.js
@@ -1,9 +1,10 @@
 const { OpenProcessingClient } = require('../../api/client');
 const { selectFields } = require('../fieldSelector');
 const { formatObject } = require('../formatters');
-const { validateId } = require('../../api/validator');
+const { validateId, VALIDATION_REASONS } = require('../../api/validator');
 const opdl = require('../../index');
 const { getToken } = require('../../config');
+const { reportHealthAfterFailure } = require('./health');
 
 /**
  * Handle sketch-related commands
@@ -55,6 +56,19 @@ async function handleSketchCommand(args) {
     const result = await opdl(sketchId, { ...downloadOptions, token });
 
     if (!result.success) {
+      // Expected conditions (missing/private/hidden sketches) are the user's
+      // problem, not the API's — only probe health for genuinely unexpected
+      // failures so we can tell an API outage apart from a plain bug.
+      const expectedReasons = [
+        VALIDATION_REASONS.NOT_FOUND,
+        VALIDATION_REASONS.PRIVATE,
+        VALIDATION_REASONS.CODE_HIDDEN,
+        VALIDATION_REASONS.DELETED,
+        VALIDATION_REASONS.INVALID_ID,
+      ];
+      if (!expectedReasons.includes(result.unavailableReason)) {
+        await reportHealthAfterFailure({ token, quiet: args.options.quiet });
+      }
       throw new Error(result.sketchInfo.error || 'Failed to download sketch');
     }
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -6,7 +6,7 @@
 
 /**
  * @typedef {Object} ParsedCommand
- * @property {'fields'|'sketch'|'user'|'curation'} command - Main command
+ * @property {'fields'|'sketch'|'user'|'curation'|'auth'|'health'} command - Main command
  * @property {string} [subcommand] - Subcommand (download, info, sketches, etc.)
  * @property {string|number} [id] - Entity ID
  * @property {Object} options - Command options
@@ -44,6 +44,14 @@ function parseArgs(argv) {
   if (argv[0] === 'auth') {
     return {
       command: 'auth',
+      options: parseOptions(argv.slice(1)),
+    };
+  }
+
+  // Handle: opdl health [options]
+  if (argv[0] === 'health') {
+    return {
+      command: 'health',
       options: parseOptions(argv.slice(1)),
     };
   }

--- a/src/fetcher.js
+++ b/src/fetcher.js
@@ -113,7 +113,17 @@ const fetchSketchInfo = async (sketchId, options = {}) => {
   };
 
   // Fetch metadata
-  const { data: metadata } = await fetchData(`https://openprocessing.org/api/sketch/${parsedId}`, `metadata of sketch ${parsedId}`, { quiet, token });
+  const { data: metadata, error: metadataError } = await fetchData(`https://openprocessing.org/api/sketch/${parsedId}`, `metadata of sketch ${parsedId}`, { quiet, token });
+
+  // A transport-level failure yields `data: null` with an error set. Left to
+  // validateSketch, a null response is classified as NOT_FOUND — which would
+  // masquerade an API outage as a missing sketch and skip the health probe.
+  // Flag it as API_ERROR so callers treat it as an unexpected/transient failure.
+  if (metadata == null && metadataError) {
+    setUnavailable(VALIDATION_REASONS.API_ERROR, metadataError);
+    sketchInfo.metadata = {};
+    return sketchInfo;
+  }
 
   // Validate metadata
   const metadataValidation = validateSketch(metadata, { type: 'metadata' });

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ const opdl = async (sketchId, options = {}) => {
     success: false,
     sketchId: String(sketchId || ''),
     outputPath: null,
+    unavailableReason: null,
     sketchInfo: {
       title: '',
       author: '',
@@ -53,6 +54,7 @@ const opdl = async (sketchId, options = {}) => {
   result.sketchInfo.engineURL = sketchInfo.engineURL || sketchInfo.metadata?.engineURL || '';
   result.sketchInfo.visualID = sketchInfo.visualID || sketchInfo.metadata?.visualID || String(sketchId);
   result.sketchInfo.isFork = sketchInfo.isFork;
+  result.unavailableReason = sketchInfo.unavailableReason || null;
   if (sketchInfo.error) {
     result.sketchInfo.error = sketchInfo.error;
   }

--- a/tests/api/client.test.mjs
+++ b/tests/api/client.test.mjs
@@ -419,6 +419,43 @@ describe('OpenProcessingClient', () => {
     });
   });
 
+  describe('getHealth', () => {
+    it('returns ok:true with parsed status/version for a healthy API', async () => {
+      nock(BASE_URL)
+        .get('/api/health')
+        .reply(200, {
+          success: true,
+          message: 'OK',
+          object: { status: 'ok', timestamp: '2026-05-17 09:49:11', version: '23.0.10' },
+          code: 200,
+        });
+
+      const health = await client.getHealth();
+      assert.equal(health.ok, true);
+      assert.equal(health.status, 'ok');
+      assert.equal(health.version, '23.0.10');
+      assert.equal(health.httpStatus, 200);
+    });
+
+    it('returns ok:false for a non-ok status without throwing', async () => {
+      nock(BASE_URL)
+        .get('/api/health')
+        .reply(200, { success: true, object: { status: 'degraded', version: '23.0.10' } });
+
+      const health = await client.getHealth();
+      assert.equal(health.ok, false);
+      assert.equal(health.status, 'degraded');
+    });
+
+    it('returns ok:false and the HTTP status for a 5xx response without throwing', async () => {
+      nock(BASE_URL).get('/api/health').reply(503, { success: false });
+
+      const health = await client.getHealth();
+      assert.equal(health.ok, false);
+      assert.equal(health.httpStatus, 503);
+    });
+  });
+
   describe('Existing Methods - Regression Tests', () => {
     it('getSketch should still work with validation', async () => {
       const mockSketch = {

--- a/tests/api/validator.test.mjs
+++ b/tests/api/validator.test.mjs
@@ -130,6 +130,18 @@ describe('Validator Module', () => {
       assert.equal(result.canRetry, true);
     });
 
+    it('should classify a "doesn\'t exist" envelope as not_found (not a transient error)', () => {
+      const response = {
+        success: false,
+        message: "Sketch doesn't exist.",
+      };
+      const result = validateResponse(response, 'sketch');
+      assert.equal(result.valid, false);
+      assert.equal(result.reason, VALIDATION_REASONS.NOT_FOUND);
+      assert.equal(result.message, "Sketch doesn't exist.");
+      assert.equal(result.canRetry, false);
+    });
+
     it('should return null for valid response', () => {
       const response = {
         success: true,

--- a/tests/cli/cli.test.mjs
+++ b/tests/cli/cli.test.mjs
@@ -3,6 +3,24 @@ import { parseArgs, parseOptions } from '../../src/cli/index.js';
 
 describe('CLI Parser', () => {
   describe('parseArgs', () => {
+    describe('health command', () => {
+      it('should parse health command', () => {
+        const result = parseArgs(['health']);
+        expect(result).toEqual({
+          command: 'health',
+          options: {}
+        });
+      });
+
+      it('should parse health command with --json', () => {
+        const result = parseArgs(['health', '--json']);
+        expect(result).toEqual({
+          command: 'health',
+          options: { json: true }
+        });
+      });
+    });
+
     describe('fields command', () => {
       it('should parse fields command without field set', () => {
         const result = parseArgs(['fields']);

--- a/tests/cli/commands/health.test.mjs
+++ b/tests/cli/commands/health.test.mjs
@@ -1,0 +1,174 @@
+import { describe, it, beforeEach, afterEach, vi, expect } from 'vitest';
+import nock from 'nock';
+import {
+  handleHealthCommand,
+  checkHealth,
+  formatHealth,
+  reportHealthAfterFailure,
+} from '../../../src/cli/commands/health.js';
+
+const BASE_URL = 'https://openprocessing.org';
+
+const HEALTHY = {
+  success: true,
+  message: 'OK',
+  object: { status: 'ok', timestamp: '2026-05-17 09:49:11', version: '23.0.10' },
+  code: 200,
+};
+
+describe('checkHealth', () => {
+  beforeEach(() => {
+    vi.stubEnv('NO_COLOR', '1');
+    nock.cleanAll();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    nock.cleanAll();
+  });
+
+  it('returns ok:true with version for a healthy API', async () => {
+    nock(BASE_URL).get('/api/health').reply(200, HEALTHY);
+    const health = await checkHealth();
+    expect(health.ok).toBe(true);
+    expect(health.status).toBe('ok');
+    expect(health.version).toBe('23.0.10');
+    expect(health.reachable).toBe(true);
+  });
+
+  it('returns ok:false for a degraded status', async () => {
+    nock(BASE_URL)
+      .get('/api/health')
+      .reply(200, { success: true, object: { status: 'degraded', version: '23.0.10' } });
+    const health = await checkHealth();
+    expect(health.ok).toBe(false);
+    expect(health.status).toBe('degraded');
+    expect(health.reachable).toBe(true);
+  });
+
+  it('returns ok:false for a non-200 status', async () => {
+    nock(BASE_URL).get('/api/health').reply(503, { success: false });
+    const health = await checkHealth();
+    expect(health.ok).toBe(false);
+    expect(health.httpStatus).toBe(503);
+    expect(health.reachable).toBe(true);
+  });
+
+  it('marks the API unreachable on a network error', async () => {
+    nock(BASE_URL).get('/api/health').replyWithError('connection refused');
+    const health = await checkHealth();
+    expect(health.ok).toBe(false);
+    expect(health.reachable).toBe(false);
+    expect(health.error).toMatch(/connection refused/);
+  });
+});
+
+describe('formatHealth', () => {
+  beforeEach(() => vi.stubEnv('NO_COLOR', '1'));
+  afterEach(() => vi.unstubAllEnvs());
+
+  it('renders OK and version for a healthy API', () => {
+    const out = formatHealth({ ok: true, status: 'ok', version: '23.0.10', reachable: true });
+    expect(out).toMatch(/OpenProcessing API: OK/);
+    expect(out).toMatch(/API version: 23\.0\.10/);
+  });
+
+  it('renders unreachable with the error text', () => {
+    const out = formatHealth({ reachable: false, error: 'timeout' });
+    expect(out).toMatch(/unreachable/);
+    expect(out).toMatch(/timeout/);
+  });
+});
+
+describe('handleHealthCommand', () => {
+  let logSpy;
+  let errSpy;
+
+  beforeEach(() => {
+    vi.stubEnv('NO_COLOR', '1');
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    nock.cleanAll();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    nock.cleanAll();
+  });
+
+  it('prints human-readable status for a healthy API', async () => {
+    nock(BASE_URL).get('/api/health').reply(200, HEALTHY);
+    await handleHealthCommand({ options: {} });
+    expect(logSpy.mock.calls[0][0]).toMatch(/OpenProcessing API: OK/);
+  });
+
+  it('prints JSON when --json is set', async () => {
+    nock(BASE_URL).get('/api/health').reply(200, HEALTHY);
+    await handleHealthCommand({ options: { json: true } });
+    const parsed = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.version).toBe('23.0.10');
+  });
+
+  it('throws with exitCode 1 for an unhealthy API', async () => {
+    nock(BASE_URL).get('/api/health').reply(503, { success: false });
+    await expect(handleHealthCommand({ options: {} })).rejects.toMatchObject({
+      exitCode: 1,
+    });
+  });
+
+  it('suppresses output when --quiet is set', async () => {
+    nock(BASE_URL).get('/api/health').reply(200, HEALTHY);
+    await handleHealthCommand({ options: { quiet: true } });
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('marks the error as reported under --quiet so the global handler stays silent', async () => {
+    nock(BASE_URL).get('/api/health').reply(503, { success: false });
+    await expect(handleHealthCommand({ options: { quiet: true } })).rejects.toMatchObject({
+      exitCode: 1,
+      reported: true,
+    });
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('reportHealthAfterFailure', () => {
+  let errSpy;
+
+  beforeEach(() => {
+    vi.stubEnv('NO_COLOR', '1');
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    nock.cleanAll();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    nock.cleanAll();
+  });
+
+  it('points at a likely opdl/sketch bug when the API is healthy', async () => {
+    nock(BASE_URL).get('/api/health').reply(200, HEALTHY);
+    await reportHealthAfterFailure({});
+    expect(errSpy.mock.calls[0][0]).toMatch(/healthy/);
+    expect(errSpy.mock.calls[0][0]).toMatch(/github\.com\/SableRaf\/opdl\/issues/);
+  });
+
+  it('points at an API issue when the API is unhealthy', async () => {
+    nock(BASE_URL).get('/api/health').reply(503, { success: false });
+    await reportHealthAfterFailure({});
+    expect(errSpy.mock.calls[0][0]).toMatch(/OpenProcessing API/);
+    expect(errSpy.mock.calls[0][0]).toMatch(/API issue/);
+  });
+
+  it('reports connectivity/outage when the API is unreachable', async () => {
+    nock(BASE_URL).get('/api/health').replyWithError('ENOTFOUND');
+    await reportHealthAfterFailure({});
+    expect(errSpy.mock.calls[0][0]).toMatch(/Could not reach/);
+  });
+
+  it('stays silent when --quiet is set', async () => {
+    await reportHealthAfterFailure({ quiet: true });
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/download/fetcher.test.mjs
+++ b/tests/download/fetcher.test.mjs
@@ -173,6 +173,22 @@ describe('fetcher', () => {
       expect(result.codeParts).toHaveLength(0);
     });
 
+    it('classifies a metadata transport failure as API_ERROR, not NOT_FOUND', async () => {
+      const sketchId = 12345;
+
+      nock('https://openprocessing.org')
+        .get(`/api/sketch/${sketchId}`)
+        .replyWithError('ECONNRESET');
+
+      const result = await fetchSketchInfo(sketchId, { quiet: true });
+
+      expect(result.available).toBe(false);
+      // A network failure must not masquerade as a missing sketch — otherwise
+      // the caller's health probe would be skipped during an outage.
+      expect(result.unavailableReason).toBe(VALIDATION_REASONS.API_ERROR);
+      expect(result.metadata).toEqual({});
+    });
+
     it('should handle fork sketches correctly', async () => {
       const sketchId = 12345;
       const parentId = 67890;


### PR DESCRIPTION
Introduce `opdl health` with human-readable or JSON output, quiet mode, and non-zero exit codes when the API is degraded or unreachable for CI/script use. Add `OpenProcessingClient.getHealth()` to parse health endpoint responses without throwing on non-2xx statuses, and add validator support for classifying "doesn't exist" responses as `NOT_FOUND`. Sketch downloads now run a post-failure health probe only for unexpected failures (not missing/private/hidden/invalid cases), and docs/tests were updated to cover the new command and behavior.

Fixes #24 