### PR TITLE
Large Processing.js support refactor and new sketch folder structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,15 +176,18 @@ npx vitest tests/fieldSelector.test.mjs
 Downloaded sketches create this structure:
 ```
 sketch_{id}/
-├── index.html              # Generated HTML entry point
-├── sketch.js               # Code files with attribution comments
-├── [assets]/               # Images, sounds, data files
+├── sketch/{name}/          # Runnable sketch, named after its main code file
+│   ├── index.html          # Generated HTML entry point (canvas form for pjs)
+│   ├── [code files]        # Code with attribution comments (.pde for pjs)
+│   └── [assets]            # Images, sounds, data files
 ├── LICENSE                 # Creative Commons or other license
 ├── OPENPROCESSING.md       # Human-readable metadata
 └── metadata/
     ├── metadata.json       # Raw API response
     └── thumbnail.jpg       # Visual thumbnail (if enabled)
 ```
+
+The runnable sketch lives in `sketch/{name}/`; opdl's bookkeeping stays at the top level. For `pjs` (Processing.js) sketches, `{name}` is the main `.pde` file, so `sketch/{name}/` opens directly in the Processing PDE.
 
 ## Important Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ npx vitest tests/fieldSelector.test.mjs
 3. **Downloader** ([src/downloader.js](src/downloader.js)) - Downloads code, assets, generates HTML
 4. **Output Generation** - Creates LICENSE, OPENPROCESSING.md, adds attribution comments
 
+**Output layout**: `<outputDir>/sketch/<name>/` holds the runnable sketch (code, `index.html`, assets); `<outputDir>/{metadata/,LICENSE,OPENPROCESSING.md}` holds opdl's bookkeeping. `<name>` comes from the main code file — for `pjs` (Processing.js) sketches specifically, that's the main `.pde` file, so the sketch folder opens directly in the Processing PDE (no `sketch.properties`). `pjs` tabs are written as `.pde` (not `.js`) and wired into `index.html` via `<canvas data-processing-sources="...">`. `downloadSketch()` returns `{ outputDir, metadataDir, sketchDir, sketchName, codeFiles }`; the public `opdl()` result also exposes `sketchName`/`sketchPath`.
+
 ### CLI Architecture
 
 **Command Flow**: `bin/opdl.js` → [src/cli.js](src/cli.js) (parser) → `src/commands/*` (handlers) → API client

--- a/HELP.md
+++ b/HELP.md
@@ -346,7 +346,7 @@ npm install && npm run dev
 
 Downloads each available sketch for offline use and creates a Vite gallery with grid and slideshow views. Edit `public/gallery.yaml` for global playback timing. Titles and authors are read from each sketch's `metadata/metadata.json`, where optional `titleOverride` and `authorOverride` properties may also be added. `--max` is an alias for `--limit`.
 
-Use `--mode` to download only sketches of a given mode, e.g. `--mode pjs` (Processing.js) or `--mode p5js,pjs` (comma-separated, case-insensitive). `processingjs` is accepted as an alias for `pjs`. The filter is applied to the sketches returned by `--limit`/`--offset`, so it does not fetch extra pages to reach a limit. If no sketch matches, nothing is downloaded and no gallery is created.
+Use `--mode` to download only sketches of a given mode, e.g. `--mode pjs` (Processing.js) or `--mode p5js,pjs` (comma-separated, case-insensitive). `processingjs` is accepted as an alias for `pjs`. The filter is applied to the sketches returned by `--limit`/`--offset`, so it does not fetch extra pages to reach a limit. If no sketch matches, nothing is downloaded and no gallery is created. Each sketch (including `pjs` ones) is downloaded under its own nested `sketch/<name>/` folder, same as a standalone download; the gallery links to it automatically.
 
 If a sketch folder already exists, opdl asks whether to skip it (the default), overwrite it, apply either choice to all remaining existing sketches, or cancel the download. Skipped sketches keep their local files (including any metadata overrides) and stay in the gallery. Use `--overwrite` or `--skipExisting` to set the policy up front without prompting; non-interactive sessions (piped output, CI, or `--quiet`) skip existing sketches by default.
 
@@ -462,7 +462,19 @@ Options specific to sketch download operations.
 
 #### `--outputDir <path>`
 
-Specify the output directory for downloaded files. Defaults to current directory.
+Specify the output directory for downloaded files. Defaults to `sketch_<id>` in the current directory.
+
+Inside that directory, the runnable sketch (code, `index.html`, assets) is nested under `sketch/<name>/`, separate from opdl's bookkeeping (`metadata/`, `LICENSE`, `OPENPROCESSING.md`), which stays at the top level:
+
+```
+<outputDir>/
+├── sketch/<name>/     # code, index.html, style.css, assets
+├── metadata/
+├── LICENSE
+└── OPENPROCESSING.md
+```
+
+`<name>` is derived from the sketch's main code file — for `pjs` (Processing.js) sketches, that's the main `.pde` file, so `sketch/<name>/` also opens natively in the Processing PDE.
 
 **Examples:**
 ```bash
@@ -499,15 +511,17 @@ opdl 1142958 --skipAssets
 
 #### `--vite`
 
-Set up a Vite project structure for modern web development.
+Set up a Vite project structure for modern web development, scaffolded inside `sketch/<name>/`.
 
-This will:
+For p5.js and plain HTML/JS sketches, this will:
 - Create a `package.json` with Vite as a dependency
 - Create a `vite.config.js` configuration file
 - Move code files to a `src/` directory
 - Move assets to a `public/` directory
 - Update `index.html` to work with Vite's module system
 - Install dependencies automatically (unless `--quiet` is set)
+
+For `pjs` (Processing.js) sketches, nothing moves: the `.pde` files, any `.js` helpers, CSS, and downloaded assets all stay at the project root so the same folder keeps opening in the Processing PDE. `index.html` is left untouched (Vite serves it as-is in dev); at build time a generated `vite.config.js` plugin copies exactly the files opdl downloaded — never "everything in the directory" — into `dist/`, so stray files (e.g. a `.env` you dropped in later) are never published.
 
 **Requirements:**
 - Node.js 20 or higher (required by Vite 6)
@@ -518,7 +532,7 @@ opdl 1142958 --vite
 opdl sketch download 1142958 --vite --outputDir ./projects
 ```
 
-After setup, run `npm run dev` in the sketch directory to start the development server.
+After setup, `opdl` prints the exact command to run, e.g. `cd 'sketch_1142958/sketch/MySketch' && npm run dev`.
 
 #### `--run`
 
@@ -611,8 +625,9 @@ opdl 1142958 --vite --quiet
 # Download with Vite and automatically start dev server
 opdl 1142958 --vite --run
 
-# After download (without --run), start development server manually
-cd sketch_1142958
+# After download (without --run), start the development server manually
+# using the exact command opdl printed, e.g.:
+cd sketch_1142958/sketch/MySketch
 npm run dev
 
 # Build for production
@@ -891,6 +906,10 @@ const opdl = require('opdl');
 
   if (result.success) {
     console.log(`Downloaded: ${result.sketchInfo.title}`);
+    // result.sketchPath is the nested sketch/<name>/ folder containing the
+    // runnable sketch (code, index.html, assets); result.outputPath is the
+    // top-level folder that also holds metadata/, LICENSE, OPENPROCESSING.md.
+    console.log(`Sketch files: ${result.sketchPath}`);
   } else {
     console.error(`Error: ${result.sketchInfo.error}`);
   }

--- a/README.md
+++ b/README.md
@@ -113,15 +113,21 @@ When you download a sketch, `opdl` creates a new directory with the following st
 
 ```
 sketch_{id}/
-├── index.html             # Generated HTML for JS/CSS sketches
-├── [code files].js/.css   # Sanitized originals with attribution comments
-├── [assets]               # Images, sounds, etc.
-├── LICENSE                # Creative Commons notice (if provided)
-├── OPENPROCESSING.md      # Human-friendly metadata summary
+├── sketch/
+│   └── {name}/             # Named after the sketch's main code file
+│       ├── index.html      # Generated HTML for JS/CSS/pjs sketches
+│       ├── [code files]    # Sanitized originals with attribution comments
+│       └── [assets]        # Images, sounds, etc.
+├── LICENSE                 # Creative Commons notice (if provided)
+├── OPENPROCESSING.md       # Human-friendly metadata summary
 └── metadata/
-    ├── metadata.json      # Raw API response
-    └── thumbnail.jpg      # Visual thumbnail (if enabled)
+    ├── metadata.json       # Raw API response
+    └── thumbnail.jpg       # Visual thumbnail (if enabled)
 ```
+
+The runnable sketch (code, `index.html`, assets) lives in `sketch/{name}/`, separate from opdl's own bookkeeping (`metadata/`, `LICENSE`, `OPENPROCESSING.md`) at the top level. `{name}` is derived from the sketch's main code file, so `sketch/{name}/` opens cleanly on its own — handy when sharing or zipping just the sketch.
+
+**Processing.js (`pjs`) sketches** are downloaded as `.pde` files (real Processing/Java-like code, not JavaScript) alongside a generated `index.html` that loads them via a `<canvas data-processing-sources="...">` element — the same folder opens natively in the Processing PDE (no `sketch.properties` needed, since the folder is named after the main `.pde` file) and also runs in a browser via `--run` or `--vite`. Any `.js` tabs on a pjs sketch are helper scripts that run in the browser only — they won't execute inside the Processing PDE.
 
 ## Licenses and attribution
 
@@ -137,4 +143,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on contributing to the pro
 
 ## Acknowledgements
 
-This project is not affiliated with [OpenProcessing](https://openprocessing.org/), and is not officially supported. Thanks to Sinan Ascioglu for creating OpenProcessing and providing the API at https://openprocessing.org/api, making this project possible. Thanks to the Processing community for sharing their creative work for others to learn from and enjoy.
+This project is not affiliated with [OpenProcessing](https://openprocessing.org/), and is not officially supported. Thanks to Sinan Ascioglu for creating OpenProcessing and providing the API at https://openprocessing.org/api, making this project possible. Thanks to the Processing community for sharing their creative work for others to learn from and enjoy.s

--- a/README.md
+++ b/README.md
@@ -143,4 +143,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on contributing to the pro
 
 ## Acknowledgements
 
-This project is not affiliated with [OpenProcessing](https://openprocessing.org/), and is not officially supported. Thanks to Sinan Ascioglu for creating OpenProcessing and providing the API at https://openprocessing.org/api, making this project possible. Thanks to the Processing community for sharing their creative work for others to learn from and enjoy.s
+This project is not affiliated with [OpenProcessing](https://openprocessing.org/), and is not officially supported. Thanks to Sinan Ascioglu for creating OpenProcessing and providing the API at https://openprocessing.org/api, making this project possible. Thanks to the Processing community for sharing their creative work for others to learn from and enjoy.

--- a/src/download/codeAttributor.js
+++ b/src/download/codeAttributor.js
@@ -20,7 +20,7 @@ const getLicenseDisplay = (licenseCode) => {
 // Only prepend attribution to file types where a leading comment is always safe.
 // Notably shaders are excluded: GLSL requires the `#version` directive on the very
 // first line, so a prepended comment block breaks compilation.
-const ATTRIBUTION_EXTENSIONS = new Set(['.js', '.html', '.htm']);
+const ATTRIBUTION_EXTENSIONS = new Set(['.js', '.html', '.htm', '.pde']);
 
 const shouldAddAttribution = (fileExtension = '') =>
   ATTRIBUTION_EXTENSIONS.has(fileExtension.toLowerCase());

--- a/src/download/codeFileWriter.js
+++ b/src/download/codeFileWriter.js
@@ -5,6 +5,80 @@ const { sanitizeFilename, rewriteAssetReferences, dedupeFilename } = require('..
 const { buildCommentBlock, shouldAddAttribution } = require('./codeAttributor');
 
 /**
+ * Pure filename resolution: sanitize/fallback/extension handling, no dedup.
+ *
+ * The extension is captured from the raw title before sanitization, because
+ * `path.extname('.pde')` is `''` — a title that IS the extension (e.g. '.pde')
+ * has no stem, so it must be special-cased rather than concatenated (naive
+ * handling would yield '.pde.pde'). Deduplication against sibling files is
+ * deliberately not part of this function; callers own that with
+ * `dedupeFilename` + a `usedNames` Set.
+ *
+ * @param {Object} params
+ * @param {string} [params.title] - Raw title from the API.
+ * @param {number} params.index - Zero-based index for the indexed fallback.
+ * @param {string} [params.fallbackBase='part'] - Base name when title is missing/unusable.
+ * @param {string} [params.defaultExtension='.js'] - Extension applied when the title has none.
+ * @param {boolean} [params.indexedFallback=true] - Whether the fallback includes `_${index + 1}`.
+ * @returns {string}
+ */
+function resolveCodeFileName({
+  title,
+  index,
+  fallbackBase = 'part',
+  defaultExtension = '.js',
+  indexedFallback = true,
+}) {
+  const raw = path.basename(title || '');
+  const isBareExtension = raw.toLowerCase() === defaultExtension.toLowerCase();
+  const originalExt = isBareExtension ? defaultExtension : path.extname(raw);
+  const intendedExt = originalExt || defaultExtension;
+  const rawStem = isBareExtension ? '' : raw.slice(0, raw.length - originalExt.length);
+  const fallbackStem = indexedFallback ? `${fallbackBase}_${index + 1}` : fallbackBase;
+  const sanitized = sanitizeFilename(`${rawStem}${intendedExt}`);
+  const sanitizedStem = sanitized.toLowerCase().endsWith(intendedExt.toLowerCase())
+    ? sanitized.slice(0, -intendedExt.length)
+    : '';
+  return sanitizedStem ? sanitized : `${fallbackStem}${intendedExt}`;
+}
+
+/**
+ * Validate a caller-supplied resolved filename before trusting it as a write
+ * target: must be a bare basename (no traversal/absolute paths), equal to its
+ * own sanitized form, have a nonempty stem, and resolve inside outputDir.
+ *
+ * @param {string} resolvedFileName
+ * @param {string} outputDir
+ * @returns {boolean}
+ */
+function isValidResolvedFileName(resolvedFileName, outputDir) {
+  if (typeof resolvedFileName !== 'string' || !resolvedFileName) {
+    return false;
+  }
+  if (resolvedFileName !== path.basename(resolvedFileName)) {
+    return false;
+  }
+  if (sanitizeFilename(resolvedFileName) !== resolvedFileName) {
+    return false;
+  }
+  const ext = path.extname(resolvedFileName);
+  // A name that IS its own extension (e.g. '.js') has no real stem — Node's
+  // path.extname returns '' for dotfiles, so this must be special-cased
+  // rather than trusting `stem = resolvedFileName` in that branch.
+  const isBareExtension = !ext && resolvedFileName.startsWith('.');
+  const stem = ext ? resolvedFileName.slice(0, -ext.length) : resolvedFileName;
+  if (isBareExtension || !stem) {
+    return false;
+  }
+  const resolved = path.resolve(outputDir, resolvedFileName);
+  const resolvedOutputDir = path.resolve(outputDir);
+  if (resolved !== path.join(resolvedOutputDir, resolvedFileName)) {
+    return false;
+  }
+  return resolved === resolvedOutputDir || resolved.startsWith(`${resolvedOutputDir}${path.sep}`);
+}
+
+/**
  * Write a single code block to disk, deduplicating filename collisions inside outputDir.
  *
  * @param {Object} params
@@ -14,6 +88,9 @@ const { buildCommentBlock, shouldAddAttribution } = require('./codeAttributor');
  * @param {Object} params.sketchInfo - Used by buildCommentBlock for attribution.
  * @param {boolean} params.addSourceComments - Whether to prepend the attribution block.
  * @param {string} [params.fallbackBase='part'] - Base name when title is missing.
+ * @param {string} [params.defaultExtension='.js'] - Extension applied when the title has none.
+ * @param {string} [params.resolvedFileName] - Precomputed filename from a prepass; validated,
+ *   and rejected (throws) if unsafe. When omitted, resolved internally via resolveCodeFileName.
  * @param {Set<string>} params.usedNames - Caller-owned Set; mutated to track collisions.
  * @param {Array<{original: string, sanitized: string}>} [params.assetRenames=[]] -
  *   Asset filename rewrites to apply to the code so references match the
@@ -27,6 +104,8 @@ function writeCodeFile({
   sketchInfo,
   addSourceComments,
   fallbackBase = 'part',
+  defaultExtension = '.js',
+  resolvedFileName,
   usedNames,
   assetRenames = [],
 }) {
@@ -34,20 +113,27 @@ function writeCodeFile({
     throw new Error('writeCodeFile: usedNames Set is required');
   }
 
-  const name = codeBlock.title || `${fallbackBase}_${index + 1}`;
-  let codeFileName = path.basename(name);
-  let fileExtension = path.extname(codeFileName);
-
-  if (!fileExtension) {
-    fileExtension = '.js';
-    codeFileName += fileExtension;
+  let codeFileName;
+  if (resolvedFileName !== undefined) {
+    if (!isValidResolvedFileName(resolvedFileName, outputDir)) {
+      throw new Error(`writeCodeFile: invalid resolvedFileName "${resolvedFileName}"`);
+    }
+    codeFileName = resolvedFileName;
+  } else {
+    codeFileName = resolveCodeFileName({
+      title: codeBlock.title,
+      index,
+      fallbackBase,
+      defaultExtension,
+    });
   }
+  const fileExtension = path.extname(codeFileName) || defaultExtension;
 
-  codeFileName = sanitizeFilename(codeFileName) || `${fallbackBase}_${index + 1}.js`;
-  // Recompute the extension after sanitization (in case sanitize stripped it).
-  fileExtension = path.extname(codeFileName) || '.js';
-
-  // De-dup within outputDir.
+  // De-dup within outputDir. When resolvedFileName came from a prepass that
+  // already deduped against its own temporary Set, replaying the same names
+  // in the same order against a fresh usedNames Set here is a no-op — it's
+  // still required so rootUsedNames ends up populated for downstream
+  // asset-collision logic.
   codeFileName = dedupeFilename(codeFileName, usedNames);
   usedNames.add(codeFileName);
 
@@ -67,4 +153,4 @@ function writeCodeFile({
   };
 }
 
-module.exports = { writeCodeFile };
+module.exports = { writeCodeFile, resolveCodeFileName };

--- a/src/download/codeFileWriter.js
+++ b/src/download/codeFileWriter.js
@@ -24,11 +24,11 @@ const { buildCommentBlock, shouldAddAttribution } = require('./codeAttributor');
  */
 function resolveCodeFileName({
   title,
-  index,
+  index = 0,
   fallbackBase = 'part',
   defaultExtension = '.js',
   indexedFallback = true,
-}) {
+} = {}) {
   const raw = path.basename(title || '');
   const isBareExtension = raw.toLowerCase() === defaultExtension.toLowerCase();
   const originalExt = isBareExtension ? defaultExtension : path.extname(raw);
@@ -36,9 +36,16 @@ function resolveCodeFileName({
   const rawStem = isBareExtension ? '' : raw.slice(0, raw.length - originalExt.length);
   const fallbackStem = indexedFallback ? `${fallbackBase}_${index + 1}` : fallbackBase;
   const sanitized = sanitizeFilename(`${rawStem}${intendedExt}`);
-  const sanitizedStem = sanitized.toLowerCase().endsWith(intendedExt.toLowerCase())
+  let sanitizedStem = sanitized.toLowerCase().endsWith(intendedExt.toLowerCase())
     ? sanitized.slice(0, -intendedExt.length)
     : '';
+  // A stem of all dots (e.g. '.' or '..' — from a title like '..') is a
+  // relative-path segment, not a real name: joined into the sketch folder
+  // path it would collapse out of the directory (path.join(dir, '..') === the
+  // parent). Treat it as unusable so we fall back instead.
+  if (/^\.+$/.test(sanitizedStem)) {
+    sanitizedStem = '';
+  }
   return sanitizedStem ? sanitized : `${fallbackStem}${intendedExt}`;
 }
 

--- a/src/download/curationDownloader.js
+++ b/src/download/curationDownloader.js
@@ -23,6 +23,23 @@ function sketchDirExists(outputDir) {
   return fs.readdirSync(outputDir).length > 0;
 }
 
+// Recover the sketchName of a previously-downloaded sketch from its nested
+// <outputDir>/sketch/<name>/ layout: exactly one directory child means an
+// unambiguous recovery; a missing/empty/multiple-children `sketch/` means
+// either a legacy (pre-nested) layout or a corrupted one, so sketchName is
+// omitted and callers fall back to the legacy top-level indexPath.
+function recoverSketchNameFromDisk(outputDir) {
+  const sketchRoot = path.join(outputDir, 'sketch');
+  let entries;
+  try {
+    entries = fs.readdirSync(sketchRoot, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  const dirs = entries.filter((entry) => entry.isDirectory());
+  return dirs.length === 1 ? dirs[0].name : null;
+}
+
 // Manifest entry for a sketch we kept on disk instead of re-downloading.
 // metadata/metadata.json is the offline source of truth; the listed sketch
 // data fills any gaps (e.g. metadata saving was disabled on the earlier run).
@@ -34,13 +51,17 @@ function existingManifestEntry({ id, title, sketch, dir, outputDir }) {
     // fall back to listed sketch data
   }
   const metaAuthor = typeof meta.author === 'string' ? meta.author : meta.author?.fullname;
+  const sketchName = recoverSketchNameFromDisk(outputDir);
   return {
     id: meta.visualID || id,
     title: meta.title || title,
     author: metaAuthor || meta.fullname || authorName(sketch),
     mode: meta.mode || sketch.mode || '',
     dir,
-    indexPath: `public/sketches/${dir}/index.html`,
+    ...(sketchName ? { sketchName } : {}),
+    indexPath: sketchName
+      ? `public/sketches/${dir}/sketch/${sketchName}/index.html`
+      : `public/sketches/${dir}/index.html`,
     thumbnailPath: `public/sketches/${dir}/metadata/thumbnail.jpg`,
     engineURL: meta.engineURL || '',
     available: true,
@@ -162,7 +183,10 @@ async function downloadCuration({
       author: info.author || authorName(sketch),
       mode: info.mode || sketch.mode || '',
       dir,
-      indexPath: `public/sketches/${dir}/index.html`,
+      ...(result.sketchName ? { sketchName: result.sketchName } : {}),
+      indexPath: result.sketchName
+        ? `public/sketches/${dir}/sketch/${result.sketchName}/index.html`
+        : `public/sketches/${dir}/index.html`,
       thumbnailPath: `public/sketches/${dir}/metadata/thumbnail.jpg`,
       engineURL: info.engineURL || '',
       available: true,

--- a/src/download/downloader.js
+++ b/src/download/downloader.js
@@ -4,9 +4,7 @@ const axios = require('axios');
 
 const {
   ensureDirectoryExists,
-  sanitizeFilename,
   resolveAssetFileName,
-  buildAssetRenameMap,
   resolveAssetUrl,
   dedupeFilename,
 } = require('../utils');
@@ -53,11 +51,15 @@ function resolvePrepassFileNames(codeParts, { fallbackBase, defaultExtension, in
  * tabs), and finally to 'sketch' when there are no code parts at all.
  */
 function pickSketchName(resolvedFileNames, isPjs) {
+  // Defense in depth: resolveCodeFileName already rejects all-dots stems, but
+  // the sketch name is joined into a filesystem path, so never let a bare
+  // path segment ('.'/'..') through even if a future caller supplies one.
+  const safeStem = (stem) => (stem && !/^\.+$/.test(stem) ? stem : 'sketch');
   if (isPjs) {
     const mainPde = resolvedFileNames.find((name) => name.toLowerCase().endsWith('.pde'));
     if (mainPde) {
       const ext = path.extname(mainPde);
-      return { sketchName: mainPde.slice(0, -ext.length), mainPde };
+      return { sketchName: safeStem(mainPde.slice(0, -ext.length)), mainPde };
     }
   }
   const first = resolvedFileNames[0];
@@ -66,7 +68,64 @@ function pickSketchName(resolvedFileNames, isPjs) {
   }
   const ext = path.extname(first);
   const stem = ext ? first.slice(0, -ext.length) : first;
-  return { sketchName: stem || 'sketch', mainPde: null };
+  return { sketchName: safeStem(stem), mainPde: null };
+}
+
+/**
+ * Resolve the final on-disk filename for every asset — including collision
+ * renames — up front, before any code file is written, so the code-reference
+ * rewrite map can point at the names the files actually land under.
+ *
+ * The code filenames are reserved first (the same names the write loop will
+ * produce, replayed against a temporary Set), so an asset colliding with a
+ * code object is detected here exactly as it was during the download loop.
+ * The prompt fires once per collision, in file order, identically to before —
+ * it's just moved earlier so its outcome can inform the rewrite map.
+ *
+ * @returns {Promise<Array<{ file: Object, filename: string|undefined,
+ *   assetFileName: string|null }>>} One entry per input file (indices
+ *   preserved). `assetFileName` is null for entries with no name or resolved
+ *   to 'skip-upload'.
+ */
+async function planAssetFileNames({ files, reservedCodeNames, onFilenameConflict, quiet }) {
+  // Reserve the code filenames the write loop will claim (same order, same
+  // dedupe), so asset-vs-code collisions are detected against them.
+  const usedNames = new Set();
+  for (const name of reservedCodeNames) {
+    usedNames.add(dedupeFilename(name, usedNames));
+  }
+
+  const plan = [];
+  for (let fileIndex = 0; fileIndex < files.length; fileIndex += 1) {
+    const file = files[fileIndex];
+    const filename = file?.name;
+    if (!filename) {
+      plan.push({ file, filename, assetFileName: null });
+      continue;
+    }
+
+    let assetFileName = resolveAssetFileName(filename, fileIndex);
+    // A sketch's uploaded files can collide with an authoritative code object
+    // of the same name — e.g. a stale index.html left over from an older
+    // version that points at files no longer present. Writing it blindly
+    // clobbers the code object (causing 404s at runtime), so we surface the
+    // conflict and let the user decide.
+    if (usedNames.has(assetFileName)) {
+      const action = await onFilenameConflict({ filename: assetFileName, quiet });
+      if (action === 'skip-upload') {
+        plan.push({ file, filename, assetFileName: null });
+        continue;
+      }
+      if (action === 'keep-both') {
+        // Code object keeps its canonical name; rename the uploaded file.
+        assetFileName = dedupeFilename(assetFileName, usedNames);
+      }
+      // 'overwrite-code' falls through and reuses the canonical name.
+    }
+    usedNames.add(assetFileName);
+    plan.push({ file, filename, assetFileName });
+  }
+  return plan;
 }
 
 const downloadSketch = async (sketchInfo, options = {}) => {
@@ -97,9 +156,31 @@ const downloadSketch = async (sketchInfo, options = {}) => {
   const rootUsedNames = new Set();
 
   const files = Array.isArray(sketchInfo.files) ? sketchInfo.files : [];
-  // Assets are saved under sanitized names; rewrite code references to match so
-  // loadImage/loadSound don't 404 into the dev server's HTML fallback.
-  const assetRenames = buildAssetRenameMap(files);
+  const assetBaseUrl = sketchInfo.metadata?.fileBase;
+  const shouldDownloadAssets = finalOptions.downloadAssets !== false;
+
+  // Resolve the FINAL on-disk asset names — including any collision renames —
+  // before writing code, so the reference-rewrite map points at the names the
+  // files actually land under (a later keep-both rename must not leave code
+  // pointing at the pre-collision name, which would 404 or hit the code
+  // object it collided with). The prepass reserves the code filenames first
+  // (replaying resolvedFileNames against a temporary Set exactly as the write
+  // loop will), so asset-vs-code collisions are detected here identically.
+  const assetPlan = shouldDownloadAssets && files.length
+    ? await planAssetFileNames({
+      files,
+      reservedCodeNames: resolvedFileNames,
+      onFilenameConflict,
+      quiet: finalOptions.quiet,
+    })
+    : [];
+
+  // Assets are saved under sanitized (and possibly deduped) names; rewrite code
+  // references to match so loadImage/loadSound don't 404 into the dev server's
+  // HTML fallback.
+  const assetRenames = assetPlan
+    .filter((entry) => entry.assetFileName && entry.assetFileName !== entry.filename)
+    .map((entry) => ({ original: entry.filename, sanitized: entry.assetFileName }));
 
   for (let index = 0; index < codeParts.length; index += 1) {
     const { codeFilePath, codeFileName, sanitizedCodeBlock } = writeCodeFile({
@@ -119,44 +200,23 @@ const downloadSketch = async (sketchInfo, options = {}) => {
     runtimeFiles.push(codeFileName);
   }
 
-  const assetBaseUrl = sketchInfo.metadata?.fileBase;
-  const shouldDownloadAssets = finalOptions.downloadAssets !== false;
-
   if (shouldDownloadAssets && files.length) {
     if (!assetBaseUrl) {
       if (!finalOptions.quiet) {
         console.warn('opdl: metadata.fileBase missing, cannot download assets');
       }
     } else {
-      for (let fileIndex = 0; fileIndex < files.length; fileIndex += 1) {
-        const file = files[fileIndex];
-        const filename = file?.name;
+      for (const entry of assetPlan) {
+        const { filename, assetFileName } = entry;
         if (!filename) {
           if (!finalOptions.quiet) {
             console.warn('opdl: asset entry missing name, skipping');
           }
           continue;
         }
-
-        let assetFileName = resolveAssetFileName(filename, fileIndex);
-        // A sketch's uploaded files can collide with an authoritative code
-        // object of the same name — e.g. a stale index.html left over from an
-        // older version that points at files no longer present. Writing it
-        // blindly clobbers the code object (causing 404s at runtime), so we
-        // surface the conflict and let the user decide.
-        if (rootUsedNames.has(assetFileName)) {
-          const action = await onFilenameConflict({
-            filename: assetFileName,
-            quiet: finalOptions.quiet,
-          });
-          if (action === 'skip-upload') {
-            continue;
-          }
-          if (action === 'keep-both') {
-            // Code object keeps its canonical name; rename the uploaded file.
-            assetFileName = dedupeFilename(assetFileName, rootUsedNames);
-          }
-          // 'overwrite-code' falls through and reuses the canonical name.
+        if (!assetFileName) {
+          // Resolved to 'skip-upload' during the prepass.
+          continue;
         }
         rootUsedNames.add(assetFileName);
 

--- a/src/download/downloader.js
+++ b/src/download/downloader.js
@@ -5,6 +5,7 @@ const axios = require('axios');
 const {
   ensureDirectoryExists,
   sanitizeFilename,
+  resolveAssetFileName,
   buildAssetRenameMap,
   resolveAssetUrl,
   dedupeFilename,
@@ -12,12 +13,61 @@ const {
 const { generateIndexHtml } = require('./htmlGenerator');
 const { createLicenseFile } = require('./licenseHandler');
 const { createOpMetadata } = require('./metadataWriter');
-const { writeCodeFile } = require('./codeFileWriter');
+const { writeCodeFile, resolveCodeFileName } = require('./codeFileWriter');
 const { writeTutorial } = require('./tutorialWriter');
 const { promptFilenameConflictAction } = require('./filenameConflictPrompt');
+const { canonicalizeMode } = require('./sketchMode');
 
 const META_DIR = 'metadata';
+const SKETCH_DIR = 'sketch';
 const THUMBNAIL_URL_TEMPLATE = 'https://kyoko.openprocessing.org/thumbnails/visualThumbnail{visualID}@2x.jpg';
+
+/**
+ * Resolve the final filename list for all code parts in one pass, before
+ * anything is written, so the sketch folder name (derived from the main .pde
+ * or first code file) and the actual writes can never disagree. Dedup uses a
+ * temporary Set scoped to this prepass only — the write loop starts fresh
+ * (see writeCodeFile), replaying the same names in the same order.
+ */
+function resolvePrepassFileNames(codeParts, { fallbackBase, defaultExtension, indexedFallback }) {
+  const prepassUsedNames = new Set();
+  return codeParts.map((codeBlock, index) => {
+    const name = resolveCodeFileName({
+      title: codeBlock.title,
+      index,
+      fallbackBase,
+      defaultExtension,
+      indexedFallback,
+    });
+    const deduped = dedupeFilename(name, prepassUsedNames);
+    prepassUsedNames.add(deduped);
+    return deduped;
+  });
+}
+
+/**
+ * Pick the sketch folder name for pjs sketches: the first resolved filename
+ * ending in .pde (case-insensitive), extension stripped by actual length so
+ * an uppercase .PDE is handled correctly. Falls back to the first resolved
+ * code filename when no .pde tab exists (e.g. a pjs sketch with only JS/HTML
+ * tabs), and finally to 'sketch' when there are no code parts at all.
+ */
+function pickSketchName(resolvedFileNames, isPjs) {
+  if (isPjs) {
+    const mainPde = resolvedFileNames.find((name) => name.toLowerCase().endsWith('.pde'));
+    if (mainPde) {
+      const ext = path.extname(mainPde);
+      return { sketchName: mainPde.slice(0, -ext.length), mainPde };
+    }
+  }
+  const first = resolvedFileNames[0];
+  if (!first) {
+    return { sketchName: 'sketch', mainPde: null };
+  }
+  const ext = path.extname(first);
+  const stem = ext ? first.slice(0, -ext.length) : first;
+  return { sketchName: stem || 'sketch', mainPde: null };
+}
 
 const downloadSketch = async (sketchInfo, options = {}) => {
   const finalOptions = { ...options };
@@ -30,9 +80,20 @@ const downloadSketch = async (sketchInfo, options = {}) => {
   const shouldAddSourceComments = finalOptions.addSourceComments;
   const onFilenameConflict = finalOptions.onFilenameConflict || promptFilenameConflictAction;
 
+  const isPjs = canonicalizeMode(sketchInfo.metadata?.mode) === 'pjs';
+  const codeParts = Array.isArray(sketchInfo.codeParts) ? sketchInfo.codeParts : [];
+
+  const resolverOptions = isPjs
+    ? { fallbackBase: 'sketch', defaultExtension: '.pde', indexedFallback: false }
+    : { fallbackBase: 'part', defaultExtension: '.js', indexedFallback: true };
+  const resolvedFileNames = resolvePrepassFileNames(codeParts, resolverOptions);
+  const { sketchName } = pickSketchName(resolvedFileNames, isPjs);
+  const sketchDir = path.join(outputDir, SKETCH_DIR, sketchName);
+  ensureDirectoryExists(sketchDir);
+
+  const runtimeFiles = [];
   const savedCodeFiles = [];
   const sanitizedCodeParts = [];
-  const codeParts = Array.isArray(sketchInfo.codeParts) ? sketchInfo.codeParts : [];
   const rootUsedNames = new Set();
 
   const files = Array.isArray(sketchInfo.files) ? sketchInfo.files : [];
@@ -41,18 +102,21 @@ const downloadSketch = async (sketchInfo, options = {}) => {
   const assetRenames = buildAssetRenameMap(files);
 
   for (let index = 0; index < codeParts.length; index += 1) {
-    const { codeFilePath, sanitizedCodeBlock } = writeCodeFile({
-      outputDir,
+    const { codeFilePath, codeFileName, sanitizedCodeBlock } = writeCodeFile({
+      outputDir: sketchDir,
       codeBlock: codeParts[index],
       index,
       sketchInfo,
       addSourceComments: shouldAddSourceComments,
-      fallbackBase: 'part',
+      fallbackBase: resolverOptions.fallbackBase,
+      defaultExtension: resolverOptions.defaultExtension,
+      resolvedFileName: resolvedFileNames[index],
       usedNames: rootUsedNames,
       assetRenames,
     });
     savedCodeFiles.push(codeFilePath);
     sanitizedCodeParts.push(sanitizedCodeBlock);
+    runtimeFiles.push(codeFileName);
   }
 
   const assetBaseUrl = sketchInfo.metadata?.fileBase;
@@ -64,7 +128,8 @@ const downloadSketch = async (sketchInfo, options = {}) => {
         console.warn('opdl: metadata.fileBase missing, cannot download assets');
       }
     } else {
-      for (const file of files) {
+      for (let fileIndex = 0; fileIndex < files.length; fileIndex += 1) {
+        const file = files[fileIndex];
         const filename = file?.name;
         if (!filename) {
           if (!finalOptions.quiet) {
@@ -73,7 +138,7 @@ const downloadSketch = async (sketchInfo, options = {}) => {
           continue;
         }
 
-        let assetFileName = sanitizeFilename(filename) || path.basename(filename);
+        let assetFileName = resolveAssetFileName(filename, fileIndex);
         // A sketch's uploaded files can collide with an authoritative code
         // object of the same name — e.g. a stale index.html left over from an
         // older version that points at files no longer present. Writing it
@@ -108,8 +173,9 @@ const downloadSketch = async (sketchInfo, options = {}) => {
             console.log(`opdl: downloading asset ${filename} from ${assetUrl}`);
           }
           const response = await axios.get(assetUrl, { responseType: 'arraybuffer' });
-          const assetFilePath = path.join(outputDir, assetFileName);
+          const assetFilePath = path.join(sketchDir, assetFileName);
           fs.writeFileSync(assetFilePath, response.data);
+          runtimeFiles.push(assetFileName);
         } catch (error) {
           if (!finalOptions.quiet) {
             console.warn(`opdl: failed to download asset ${filename}`);
@@ -160,7 +226,16 @@ const downloadSketch = async (sketchInfo, options = {}) => {
   }
 
   if (sketchInfo.metadata?.mode && sketchInfo.metadata.mode !== 'html') {
-    generateIndexHtml(sketchInfo.metadata, sanitizedCodeParts, outputDir);
+    generateIndexHtml(sketchInfo.metadata, sanitizedCodeParts, sketchDir);
+  }
+  const generatedStyleCssPath = path.join(sketchDir, 'style.css');
+  if (fs.existsSync(generatedStyleCssPath) && !runtimeFiles.includes('style.css')) {
+    runtimeFiles.push('style.css');
+  }
+  if (fs.existsSync(path.join(sketchDir, 'index.html')) && !runtimeFiles.includes('index.html')) {
+    // Tracked for completeness; the Vite scaffolder excludes index.html from
+    // its copy allowlist (Vite owns it) regardless of this list's contents.
+    runtimeFiles.push('index.html');
   }
 
   if (finalOptions.createLicenseFile) {
@@ -184,8 +259,9 @@ const downloadSketch = async (sketchInfo, options = {}) => {
   // Set up Vite project if requested
   if (finalOptions.vite) {
     const { scaffoldViteProject } = require('./viteScaffolder');
-    await scaffoldViteProject(outputDir, sketchInfo, {
+    await scaffoldViteProject(sketchDir, sketchInfo, {
       codeFiles: savedCodeFiles,
+      runtimeFiles,
       quiet: finalOptions.quiet,
       run: finalOptions.run,
     });
@@ -196,10 +272,12 @@ const downloadSketch = async (sketchInfo, options = {}) => {
     }
     // Run simple HTTP server for non-Vite projects
     const { runDevServer } = require('./serverRunner');
-    await runDevServer(outputDir, { vite: false, quiet: finalOptions.quiet });
+    await runDevServer(sketchDir, { vite: false, quiet: finalOptions.quiet });
   }
 
-  return { outputDir, metadataDir, codeFiles: savedCodeFiles };
+  return {
+    outputDir, metadataDir, sketchDir, sketchName, codeFiles: savedCodeFiles,
+  };
 };
 
 module.exports = { downloadSketch };

--- a/src/download/htmlGenerator.js
+++ b/src/download/htmlGenerator.js
@@ -55,18 +55,6 @@ const generateIndexHtml = (metadata, codeParts, outputDir) => {
     .join('\n    ');
   const librariesSection = libraries ? `    ${libraries}\n` : '';
 
-  const scriptTags = parts
-    .filter((part) => part.title && part.title.endsWith('.js'))
-    .map((part) => `<script src="${part.title}"></script>`)
-    .join('\n    ');
-  const scriptTagsSection = scriptTags ? `    ${scriptTags}\n` : '';
-
-  const scriptTagsDefault = parts
-    .filter((part) => part.title && !part.title.includes('.'))
-    .map((part) => `<script src="${part.title}.js"></script>`)
-    .join('\n    ');
-  const scriptTagsDefaultSection = scriptTagsDefault ? `    ${scriptTagsDefault}\n` : '';
-
   const cssLinkTags = parts
     .filter((part) => part.title && part.title.endsWith('.css'))
     .map((part) => `<link rel="stylesheet" type="text/css" href="${part.title}">`)
@@ -77,10 +65,50 @@ const generateIndexHtml = (metadata, codeParts, outputDir) => {
     ? ''
     : `    <link rel="stylesheet" type="text/css" href="style.css">\n`;
 
+  const isPjs = canonicalizeMode(metadata.mode) === 'pjs';
+  const pdeParts = isPjs
+    ? parts.filter((part) => part.title && part.title.toLowerCase().endsWith('.pde'))
+    : [];
+
+  let scriptTagsSection;
+  let scriptTagsDefaultSection;
+  let bodyContent;
+
+  if (isPjs && pdeParts.length) {
+    // pjs with .pde tabs: Processing.js concatenates all .pde sources listed
+    // on a canvas's data-processing-sources; explicit .js helper tabs stay
+    // plain scripts. No sketch.properties, no inline text/processing (avoids
+    // </script> corruption).
+    const pdeSources = pdeParts.map((part) => part.title).join(' ');
+    const jsHelperTags = parts
+      .filter((part) => part.title && part.title.toLowerCase().endsWith('.js'))
+      .map((part) => `<script src="${part.title}"></script>`)
+      .join('\n    ');
+    scriptTagsSection = jsHelperTags ? `    ${jsHelperTags}\n` : '';
+    scriptTagsDefaultSection = '';
+    bodyContent = `<canvas data-processing-sources="${pdeSources}"></canvas>\n`;
+  } else {
+    if (isPjs && !metadata.__silencePjsFallbackWarning) {
+      console.warn('opdl: pjs sketch has no .pde files; falling back to <script src> wiring');
+    }
+    const scriptTags = parts
+      .filter((part) => part.title && part.title.endsWith('.js'))
+      .map((part) => `<script src="${part.title}"></script>`)
+      .join('\n    ');
+    scriptTagsSection = scriptTags ? `    ${scriptTags}\n` : '';
+
+    const scriptTagsDefault = parts
+      .filter((part) => part.title && !part.title.includes('.'))
+      .map((part) => `<script src="${part.title}.js"></script>`)
+      .join('\n    ');
+    scriptTagsDefaultSection = scriptTagsDefault ? `    ${scriptTagsDefault}\n` : '';
+    bodyContent = '';
+  }
+
   const htmlContent = `${htmlHeadStart}${librariesSection}${scriptTagsSection}${scriptTagsDefaultSection}${cssLinkTagsSection}${defaultCssLinkSection}</head>
 
 <body>
-
+${bodyContent}
 </body>
 
 </html>`;

--- a/src/download/templates/gallery/main.js
+++ b/src/download/templates/gallery/main.js
@@ -241,6 +241,9 @@ function showPrevious() {
 }
 
 function sketchUrl(project) {
+  if (project.sketchName) {
+    return `./sketches/${encodeURIComponent(project.dir)}/sketch/${encodeURIComponent(project.sketchName)}/index.html`;
+  }
   return `./sketches/${encodeURIComponent(project.dir)}/index.html`;
 }
 

--- a/src/download/viteScaffolder.js
+++ b/src/download/viteScaffolder.js
@@ -2,6 +2,8 @@ const fs = require('fs');
 const path = require('path');
 const { spawn } = require('child_process');
 const { runDevServer } = require('./serverRunner');
+const { canonicalizeMode } = require('./sketchMode');
+const { sanitizeFilename } = require('../utils');
 
 /**
  * Escape special characters in a string so it can be used safely in a RegExp
@@ -13,11 +15,38 @@ function escapeRegExp(str) {
 }
 
 /**
+ * Shell-quote a path for the completion message's `cd` command (single
+ * quotes, with embedded `'` escaped), so directories containing spaces
+ * produce a runnable command.
+ * @param {string} p
+ * @returns {string}
+ */
+function shellQuote(p) {
+  return `'${p.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Build the `cd <path> && npm run dev` completion message. Uses a relative
+ * path from cwd when possible (falls back to absolute if the relative path
+ * escapes upward), shell-quoted so spaces in the path don't break the command.
+ * @param {string} outputDir
+ * @returns {string}
+ */
+function buildCompletionMessage(outputDir) {
+  const relative = path.relative(process.cwd(), outputDir);
+  const displayPath = relative && !relative.startsWith('..') && !path.isAbsolute(relative)
+    ? relative
+    : outputDir;
+  return `opdl: Run \`cd ${shellQuote(displayPath)} && npm run dev\` to start the development server.`;
+}
+
+/**
  * Scaffolds a Vite project in the specified output directory
  * @param {string} outputDir - Directory containing the downloaded sketch
  * @param {Object} sketchInfo - Sketch metadata and information
  * @param {Object} options - Scaffolding options
  * @param {Array} options.codeFiles - Array of saved code file paths
+ * @param {Array<string>} [options.runtimeFiles] - Runtime file allowlist (pjs only)
  * @param {boolean} options.quiet - Suppress output messages
  * @param {boolean} options.run - Automatically run dev server after setup
  * @param {Function} [options.runDevServerFn] - Test hook for runDevServer
@@ -25,6 +54,7 @@ function escapeRegExp(str) {
 async function scaffoldViteProject(outputDir, sketchInfo, options = {}) {
   const {
     codeFiles = [],
+    runtimeFiles = [],
     quiet = false,
     run = false,
     runDevServerFn = runDevServer,
@@ -48,9 +78,10 @@ async function scaffoldViteProject(outputDir, sketchInfo, options = {}) {
     return;
   }
 
+  const mode = sketchInfo.metadata?.mode;
+  const isPjs = canonicalizeMode(mode) === 'pjs';
   // For HTML mode, check if an HTML file exists
   // HTML mode means user wrote their own HTML, which we won't modify
-  const mode = sketchInfo.metadata?.mode;
   const isHtmlMode = mode === 'html';
 
   // Check if package.json already exists
@@ -67,97 +98,10 @@ async function scaffoldViteProject(outputDir, sketchInfo, options = {}) {
   }
 
   try {
-    // Create src directory
-    const srcDir = path.join(outputDir, 'src');
-    if (!fs.existsSync(srcDir)) {
-      fs.mkdirSync(srcDir, { recursive: true });
-    }
-
-    // Create public directory for assets
-    const publicDir = path.join(outputDir, 'public');
-    if (!fs.existsSync(publicDir)) {
-      fs.mkdirSync(publicDir, { recursive: true });
-    }
-
-    // Move code files to src directory (but not HTML files - Vite expects those in root)
-    const movedCodeFiles = [];
-    for (const codeFilePath of codeFiles) {
-      const fileName = path.basename(codeFilePath);
-      const ext = path.extname(fileName).toLowerCase();
-
-      // Skip HTML files - they should stay in root for Vite
-      if (ext === '.html' || ext === '.htm') {
-        continue;
-      }
-
-      const newPath = path.join(srcDir, fileName);
-      fs.renameSync(codeFilePath, newPath);
-      movedCodeFiles.push(fileName);
-    }
-
-    // Move asset files to public directory
-    const files = fs.readdirSync(outputDir);
-    const assetExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.svg', '.mp3', '.wav', '.ogg', '.mp4', '.webm', '.json', '.txt'];
-
-    // Certain config/metadata files must remain in the project root and should not be treated as assets
-    const rootConfigFiles = new Set([
-      'package.json',
-      'package-lock.json',
-      'pnpm-lock.yaml',
-      'yarn.lock',
-      'tsconfig.json',
-      'jsconfig.json',
-      '.gitignore',
-      '.gitignore.txt',
-      '.npmrc',
-      'vite.config.js',
-    ]);
-
-    for (const file of files) {
-      const fullPath = path.join(outputDir, file);
-
-      // Skip directories
-      try {
-        if (fs.statSync(fullPath).isDirectory()) {
-          continue;
-        }
-      } catch (e) {
-        continue;
-      }
-
-      const ext = path.extname(file).toLowerCase();
-
-      // Only consider known asset extensions
-      if (!assetExtensions.includes(ext)) {
-        continue;
-      }
-
-      // Skip files that should stay in the project root (e.g., config and metadata files)
-      if (rootConfigFiles.has(file.toLowerCase())) {
-        continue;
-      }
-
-      const oldPath = fullPath;
-      const newPath = path.join(publicDir, file);
-      fs.renameSync(oldPath, newPath);
-    }
-
-    // Create package.json
-    createPackageJson(outputDir, sketchInfo);
-
-    // Create vite.config.js
-    createViteConfig(outputDir);
-
-    // Update index.html for Vite
-    const indexHtmlPath = path.join(outputDir, 'index.html');
-    if (fs.existsSync(indexHtmlPath)) {
-      if (isHtmlMode) {
-        // For HTML mode, update paths to point to src/ and public/
-        updateHtmlModeFilePaths(indexHtmlPath, movedCodeFiles, outputDir);
-      } else {
-        // For generated HTML, completely rewrite script tags
-        updateIndexHtmlForVite(indexHtmlPath, movedCodeFiles);
-      }
+    if (isPjs) {
+      await scaffoldPjsViteProject(outputDir, sketchInfo, runtimeFiles);
+    } else {
+      await scaffoldGenericViteProject(outputDir, sketchInfo, codeFiles, isHtmlMode);
     }
 
     // Run npm install unless quiet mode
@@ -167,7 +111,7 @@ async function scaffoldViteProject(outputDir, sketchInfo, options = {}) {
       console.log('opdl: Vite project setup complete!');
 
       if (!run) {
-        console.log(`opdl: Run 'cd ${path.basename(outputDir)} && npm run dev' to start the development server.`);
+        console.log(buildCompletionMessage(outputDir));
       }
     } else {
       // In quiet mode, still create the project structure but skip npm install
@@ -184,6 +128,143 @@ async function scaffoldViteProject(outputDir, sketchInfo, options = {}) {
     }
     throw error;
   }
+}
+
+/**
+ * Generic (p5js/html) Vite scaffold: moves code to src/ and assets to
+ * public/, then rewrites index.html accordingly. Unchanged behavior from
+ * before the pjs branch was introduced — just extracted into its own function.
+ */
+async function scaffoldGenericViteProject(outputDir, sketchInfo, codeFiles, isHtmlMode) {
+  // Create src directory
+  const srcDir = path.join(outputDir, 'src');
+  if (!fs.existsSync(srcDir)) {
+    fs.mkdirSync(srcDir, { recursive: true });
+  }
+
+  // Create public directory for assets
+  const publicDir = path.join(outputDir, 'public');
+  if (!fs.existsSync(publicDir)) {
+    fs.mkdirSync(publicDir, { recursive: true });
+  }
+
+  // Move code files to src directory (but not HTML files - Vite expects those in root)
+  const movedCodeFiles = [];
+  for (const codeFilePath of codeFiles) {
+    const fileName = path.basename(codeFilePath);
+    const ext = path.extname(fileName).toLowerCase();
+
+    // Skip HTML files - they should stay in root for Vite
+    if (ext === '.html' || ext === '.htm') {
+      continue;
+    }
+
+    const newPath = path.join(srcDir, fileName);
+    fs.renameSync(codeFilePath, newPath);
+    movedCodeFiles.push(fileName);
+  }
+
+  // Move asset files to public directory
+  const files = fs.readdirSync(outputDir);
+  const assetExtensions = ['.png', '.jpg', '.jpeg', '.gif', '.svg', '.mp3', '.wav', '.ogg', '.mp4', '.webm', '.json', '.txt'];
+
+  // Certain config/metadata files must remain in the project root and should not be treated as assets
+  const rootConfigFiles = new Set([
+    'package.json',
+    'package-lock.json',
+    'pnpm-lock.yaml',
+    'yarn.lock',
+    'tsconfig.json',
+    'jsconfig.json',
+    '.gitignore',
+    '.gitignore.txt',
+    '.npmrc',
+    'vite.config.js',
+  ]);
+
+  for (const file of files) {
+    const fullPath = path.join(outputDir, file);
+
+    // Skip directories
+    try {
+      if (fs.statSync(fullPath).isDirectory()) {
+        continue;
+      }
+    } catch (e) {
+      continue;
+    }
+
+    const ext = path.extname(file).toLowerCase();
+
+    // Only consider known asset extensions
+    if (!assetExtensions.includes(ext)) {
+      continue;
+    }
+
+    // Skip files that should stay in the project root (e.g., config and metadata files)
+    if (rootConfigFiles.has(file.toLowerCase())) {
+      continue;
+    }
+
+    const oldPath = fullPath;
+    const newPath = path.join(publicDir, file);
+    fs.renameSync(oldPath, newPath);
+  }
+
+  // Create package.json
+  createPackageJson(outputDir, sketchInfo);
+
+  // Create vite.config.js
+  createViteConfig(outputDir);
+
+  // Update index.html for Vite
+  const indexHtmlPath = path.join(outputDir, 'index.html');
+  if (fs.existsSync(indexHtmlPath)) {
+    if (isHtmlMode) {
+      // For HTML mode, update paths to point to src/ and public/
+      updateHtmlModeFilePaths(indexHtmlPath, movedCodeFiles, outputDir);
+    } else {
+      // For generated HTML, completely rewrite script tags
+      updateIndexHtmlForVite(indexHtmlPath, movedCodeFiles);
+    }
+  }
+}
+
+/**
+ * pjs Vite scaffold: moves nothing. The dual-purpose folder (runnable in the
+ * Processing PDE and served by Vite) is preserved by leaving .pde/.js/.css
+ * and downloaded assets at the project root — data-processing-sources,
+ * helper <script src>, and loadImage relative paths all resolve unchanged in
+ * dev. Only package.json and a pjs vite.config.js (with a build-time copy
+ * plugin) are added; index.html is left untouched.
+ */
+async function scaffoldPjsViteProject(outputDir, sketchInfo, runtimeFiles) {
+  const allowlist = buildRuntimeFileAllowlist(outputDir, runtimeFiles);
+  createPackageJson(outputDir, sketchInfo);
+  createPjsViteConfig(outputDir, allowlist);
+}
+
+/**
+ * Validate and dedupe the runtime file list the downloader says it produced,
+ * for embedding into the pjs vite.config.js copy plugin. The sketch dir isn't
+ * guaranteed pristine (repeat downloads, manual edits), so this never trusts
+ * "everything in the directory" — only entries the downloader itself wrote,
+ * and only if they're safe basenames that still exist on disk at scaffold time
+ * (skipped otherwise; the copy plugin also re-checks and warns at build time).
+ */
+function buildRuntimeFileAllowlist(outputDir, runtimeFiles) {
+  const seen = new Set();
+  const allowlist = [];
+  for (const entry of runtimeFiles || []) {
+    if (typeof entry !== 'string' || !entry) continue;
+    if (entry.toLowerCase() === 'index.html') continue; // Vite owns index.html
+    if (entry !== path.basename(entry)) continue;
+    if (sanitizeFilename(entry) !== entry) continue;
+    if (seen.has(entry)) continue;
+    seen.add(entry);
+    allowlist.push(entry);
+  }
+  return allowlist;
 }
 
 function supportsVite(nodeVersion = process.version) {
@@ -229,6 +310,74 @@ function createViteConfig(outputDir) {
 
 export default defineConfig({
   base: './',
+  server: {
+    port: 3000,
+    open: true,
+  },
+  build: {
+    outDir: 'dist',
+    assetsDir: 'assets',
+  },
+});
+`;
+
+  const viteConfigPath = path.join(outputDir, 'vite.config.js');
+  fs.writeFileSync(viteConfigPath, viteConfigContent, 'utf8');
+}
+
+/**
+ * Creates vite.config.js for pjs sketches: the dev server serves the project
+ * root as-is (nothing moved, so data-processing-sources / helper <script src>
+ * / loadImage paths resolve unchanged), and an inline closeBundle plugin
+ * copies only the validated runtime file allowlist into dist/ at build time
+ * — never "everything in the directory", since repeat downloads or manual
+ * edits could otherwise leak a stray .env or debug log into the published
+ * build. Files missing at build time are skipped with a warning rather than
+ * failing the build; each resolved source/destination is re-checked to stay
+ * within the project root / dist/ as a defense-in-depth measure.
+ * @param {string} outputDir - Output directory path (the sketch dir)
+ * @param {Array<string>} allowlist - Validated runtime file basenames
+ */
+function createPjsViteConfig(outputDir, allowlist) {
+  const runtimeFilesLiteral = JSON.stringify(allowlist);
+  const viteConfigContent = `import { defineConfig } from 'vite';
+import fs from 'fs';
+import path from 'path';
+
+// Runtime files this download produced (.pde/.js/.css/downloaded assets).
+// Validated and deduplicated by opdl at download time; index.html is
+// excluded here because Vite owns it.
+const runtimeFiles = ${runtimeFilesLiteral};
+
+function copyPjsRuntimeFiles() {
+  return {
+    name: 'opdl-copy-pjs-runtime-files',
+    closeBundle() {
+      const projectRoot = path.resolve(__dirname);
+      const distDir = path.resolve(__dirname, 'dist');
+      for (const fileName of runtimeFiles) {
+        const srcPath = path.resolve(projectRoot, fileName);
+        const destPath = path.resolve(distDir, fileName);
+        if (!srcPath.startsWith(projectRoot + path.sep) && srcPath !== projectRoot) {
+          continue;
+        }
+        if (!destPath.startsWith(distDir + path.sep) && destPath !== distDir) {
+          continue;
+        }
+        if (!fs.existsSync(srcPath)) {
+          console.warn(\`opdl: runtime file missing at build time, skipping: \${fileName}\`);
+          continue;
+        }
+        fs.mkdirSync(path.dirname(destPath), { recursive: true });
+        fs.copyFileSync(srcPath, destPath);
+      }
+    },
+  };
+}
+
+export default defineConfig({
+  base: './',
+  plugins: [copyPjsRuntimeFiles()],
   server: {
     port: 3000,
     open: true,
@@ -368,4 +517,11 @@ function runNpmInstall(outputDir, quiet) {
   });
 }
 
-module.exports = { scaffoldViteProject, runNpmInstall, createViteConfig, supportsVite };
+module.exports = {
+  scaffoldViteProject,
+  runNpmInstall,
+  createViteConfig,
+  createPjsViteConfig,
+  supportsVite,
+  buildCompletionMessage,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,8 @@ const opdl = async (sketchId, options = {}) => {
     success: false,
     sketchId: String(sketchId || ''),
     outputPath: null,
+    sketchName: null,
+    sketchPath: null,
     unavailableReason: null,
     sketchInfo: {
       title: '',
@@ -72,6 +74,8 @@ const opdl = async (sketchId, options = {}) => {
     const downloadResult = await downloadSketch(sketchInfo, mergedOptions);
     result.success = true;
     result.outputPath = downloadResult.outputDir;
+    result.sketchName = downloadResult.sketchName;
+    result.sketchPath = downloadResult.sketchDir;
   } catch (error) {
     result.sketchInfo.error = error?.message || 'Failed to download sketch';
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,14 +23,40 @@ const sanitizeFilename = (filename) => {
 };
 
 /**
+ * Resolve the on-disk filename for an asset, guaranteeing a sanitization-stable
+ * result (never the raw original as a fallback, which could carry unsafe
+ * characters like quotes/backticks onto disk).
+ *
+ * @param {string} originalName - Asset name as reported by the API.
+ * @param {number} index - Zero-based index for the deterministic fallback.
+ * @returns {string}
+ */
+const resolveAssetFileName = (originalName, index) => {
+  const sanitized = sanitizeFilename(originalName || '');
+  // A sanitized result that is a bare extension (e.g. '.png', from an
+  // original like '???.png') has no usable stem and would land on disk as a
+  // hidden dotfile, not a real asset name — reject it like an empty result.
+  const sanitizedExt = path.extname(sanitized);
+  const isBareExtension = !sanitizedExt && sanitized.startsWith('.');
+  if (sanitized && !isBareExtension && sanitizeFilename(sanitized) === sanitized) {
+    return sanitized;
+  }
+  const rawExt = path.extname(path.basename(originalName || ''));
+  const sanitizedRawExt = sanitizeFilename(rawExt);
+  const ext = sanitizedRawExt && sanitizeFilename(sanitizedRawExt) === sanitizedRawExt ? sanitizedRawExt : '';
+  return `asset_${index + 1}${ext}`;
+};
+
+/**
  * Build the list of asset filename rewrites the download performs.
  *
- * Asset files are saved under `sanitizeFilename(name)` (see downloader.js), which
- * turns e.g. "Bottle slide.m4a" into "Bottle_slide.m4a". The sketch code still
- * references the original name, so without rewriting, the request 404s and the
- * dev server's HTML fallback reaches loadSound/loadImage — surfacing as an
- * opaque "Unable to decode audio data" EncodingError. Returns only the entries
- * whose on-disk name differs from the original.
+ * Asset files are saved under `resolveAssetFileName(name, index)` (see
+ * downloader.js), which turns e.g. "Bottle slide.m4a" into
+ * "Bottle_slide.m4a". The sketch code still references the original name, so
+ * without rewriting, the request 404s and the dev server's HTML fallback
+ * reaches loadSound/loadImage — surfacing as an opaque "Unable to decode
+ * audio data" EncodingError. Returns only the entries whose on-disk name
+ * differs from the original.
  *
  * @param {Array<{name?: string}>} files - Asset entries from the API.
  * @returns {Array<{original: string, sanitized: string}>}
@@ -40,17 +66,17 @@ const buildAssetRenameMap = (files) => {
   if (!Array.isArray(files)) {
     return renames;
   }
-  for (const file of files) {
+  files.forEach((file, index) => {
     const original = file?.name;
     if (!original) {
-      continue;
+      return;
     }
     // Mirror exactly what downloader.js writes to disk.
-    const sanitized = sanitizeFilename(original) || path.basename(original);
+    const sanitized = resolveAssetFileName(original, index);
     if (sanitized && sanitized !== original) {
       renames.push({ original, sanitized });
     }
-  }
+  });
   return renames;
 };
 
@@ -134,6 +160,7 @@ const dedupeFilename = (filename, usedNames) => {
 module.exports = {
   ensureDirectoryExists,
   sanitizeFilename,
+  resolveAssetFileName,
   buildAssetRenameMap,
   rewriteAssetReferences,
   resolveAssetUrl,

--- a/tests/download/codeFileWriter.test.mjs
+++ b/tests/download/codeFileWriter.test.mjs
@@ -60,6 +60,23 @@ describe('resolveCodeFileName', () => {
     expect(a).toBe('foo.js');
     expect(b).toBe('foo.js');
   });
+
+  it('treats dot-segment titles (".." / ".") as unusable so the stem can never be a path segment', () => {
+    // A title of ".." would otherwise resolve to "...pde" with stem "..",
+    // which collapses out of the sketch directory when joined into a path.
+    for (const title of ['..', '.', '../..', './..']) {
+      const r = resolveCodeFileName({
+        title, index: 0, fallbackBase: 'sketch', defaultExtension: '.pde', indexedFallback: false,
+      });
+      expect(r).toBe('sketch.pde');
+    }
+  });
+
+  it('is callable with no arguments and with a missing index (genuine defaults)', () => {
+    expect(resolveCodeFileName()).toBe('part_1.js');
+    expect(resolveCodeFileName({})).toBe('part_1.js');
+    expect(resolveCodeFileName({ title: '' })).toBe('part_1.js');
+  });
 });
 
 describe('writeCodeFile', () => {

--- a/tests/download/codeFileWriter.test.mjs
+++ b/tests/download/codeFileWriter.test.mjs
@@ -2,7 +2,65 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { writeCodeFile } from '../../src/download/codeFileWriter.js';
+import { writeCodeFile, resolveCodeFileName } from '../../src/download/codeFileWriter.js';
+
+describe('resolveCodeFileName', () => {
+  it('sanitizes the title and preserves its extension', () => {
+    expect(resolveCodeFileName({ title: 'sketch.js', index: 0 })).toBe('sketch.js');
+  });
+
+  it('falls back to fallbackBase_N.js when title is missing (indexed default)', () => {
+    expect(resolveCodeFileName({ title: undefined, index: 2 })).toBe('part_3.js');
+  });
+
+  it('falls back to fallbackBase_N.js for a punctuation-only extensionless title', () => {
+    expect(resolveCodeFileName({ title: '***', index: 0 })).toBe('part_1.js');
+  });
+
+  it('resolves a punctuation-only title to sketch.pde with the pjs non-indexed fallback', () => {
+    expect(resolveCodeFileName({
+      title: '***', index: 0, fallbackBase: 'sketch', defaultExtension: '.pde', indexedFallback: false,
+    })).toBe('sketch.pde');
+  });
+
+  it('resolves a literal ".pde" title to sketch.pde instead of ".pde.pde" or a hidden dotfile', () => {
+    expect(resolveCodeFileName({
+      title: '.pde', index: 0, fallbackBase: 'sketch', defaultExtension: '.pde', indexedFallback: false,
+    })).toBe('sketch.pde');
+  });
+
+  it('resolves an uppercase ".PDE" title the same way, case-insensitively', () => {
+    expect(resolveCodeFileName({
+      title: '.PDE', index: 0, fallbackBase: 'sketch', defaultExtension: '.pde', indexedFallback: false,
+    })).toBe('sketch.pde');
+  });
+
+  it('preserves an explicit extension even when defaultExtension differs', () => {
+    expect(resolveCodeFileName({
+      title: 'helper.js', index: 0, fallbackBase: 'sketch', defaultExtension: '.pde', indexedFallback: false,
+    })).toBe('helper.js');
+    expect(resolveCodeFileName({
+      title: 'index.html', index: 0, fallbackBase: 'sketch', defaultExtension: '.pde', indexedFallback: false,
+    })).toBe('index.html');
+  });
+
+  it('applies defaultExtension to an extensionless title', () => {
+    expect(resolveCodeFileName({
+      title: 'MySketch', index: 0, fallbackBase: 'sketch', defaultExtension: '.pde', indexedFallback: false,
+    })).toBe('MySketch.pde');
+  });
+
+  it('indexed default fallback still yields part_1.js for non-pjs callers', () => {
+    expect(resolveCodeFileName({ title: '', index: 0 })).toBe('part_1.js');
+  });
+
+  it('is pure and does not dedupe against sibling names', () => {
+    const a = resolveCodeFileName({ title: 'foo.js', index: 0 });
+    const b = resolveCodeFileName({ title: 'foo.js', index: 1 });
+    expect(a).toBe('foo.js');
+    expect(b).toBe('foo.js');
+  });
+});
 
 describe('writeCodeFile', () => {
   let dir;
@@ -121,5 +179,90 @@ describe('writeCodeFile', () => {
     });
     const resolved = path.resolve(result.codeFilePath);
     expect(resolved.startsWith(path.resolve(dir))).toBe(true);
+  });
+
+  it('applies defaultExtension when the title has none', () => {
+    const used = new Set();
+    const result = writeCodeFile({
+      outputDir: dir,
+      codeBlock: { title: 'MySketch', code: 'void setup() {}' },
+      index: 0,
+      sketchInfo: {},
+      addSourceComments: false,
+      fallbackBase: 'sketch',
+      defaultExtension: '.pde',
+      usedNames: used,
+    });
+    expect(result.codeFileName).toBe('MySketch.pde');
+  });
+
+  it('honors a valid resolvedFileName instead of recomputing one', () => {
+    const used = new Set();
+    const result = writeCodeFile({
+      outputDir: dir,
+      codeBlock: { title: 'ignored-title.js', code: 'x' },
+      index: 0,
+      sketchInfo: {},
+      addSourceComments: false,
+      resolvedFileName: 'precomputed.pde',
+      usedNames: used,
+    });
+    expect(result.codeFileName).toBe('precomputed.pde');
+    expect(fs.existsSync(path.join(dir, 'precomputed.pde'))).toBe(true);
+  });
+
+  it('still dedupes a resolvedFileName against usedNames', () => {
+    const used = new Set(['taken.pde']);
+    const result = writeCodeFile({
+      outputDir: dir,
+      codeBlock: { title: 'x', code: 'x' },
+      index: 0,
+      sketchInfo: {},
+      addSourceComments: false,
+      resolvedFileName: 'taken.pde',
+      usedNames: used,
+    });
+    expect(result.codeFileName).toBe('taken_2.pde');
+  });
+
+  describe('rejects invalid resolvedFileName', () => {
+    const used = () => new Set();
+    const attempt = (resolvedFileName) => writeCodeFile({
+      outputDir: dir,
+      codeBlock: { title: 'x', code: 'x' },
+      index: 0,
+      sketchInfo: {},
+      addSourceComments: false,
+      resolvedFileName,
+      usedNames: used(),
+    });
+
+    it('rejects traversal via ../', () => {
+      expect(() => attempt('../../evil.js')).toThrow();
+    });
+
+    it('rejects traversal via a nested path with dots', () => {
+      expect(() => attempt('foo/../../evil.js')).toThrow();
+    });
+
+    it('rejects an absolute path', () => {
+      expect(() => attempt('/etc/passwd')).toThrow();
+    });
+
+    it('rejects a name embedding a path separator', () => {
+      expect(() => attempt('sub/dir.js')).toThrow();
+    });
+
+    it('rejects a name that differs from its sanitized form', () => {
+      expect(() => attempt('my<sketch>.js')).toThrow();
+    });
+
+    it('rejects an empty-stem name', () => {
+      expect(() => attempt('.js')).toThrow();
+    });
+
+    it('rejects an empty string', () => {
+      expect(() => attempt('')).toThrow();
+    });
   });
 });

--- a/tests/download/curationDownloader.test.mjs
+++ b/tests/download/curationDownloader.test.mjs
@@ -223,6 +223,112 @@ describe('downloadCuration', () => {
     }
   });
 
+  it('manifest entry gets sketchName and a nested indexPath when opdlFn reports one', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-curation-'));
+    try {
+      const client = conflictClient([{ visualID: 1, title: 'A' }]);
+      const opdlFn = vi.fn(async (id) => ({
+        success: true,
+        sketchName: 'MySketch',
+        sketchInfo: { visualID: id, title: 'A' },
+      }));
+      const result = await downloadCuration({
+        curationId: 9, client, opdlFn, scaffoldFn: vi.fn(),
+        options: { outputDir: root, quiet: true },
+      });
+      expect(result.manifest[0]).toMatchObject({
+        sketchName: 'MySketch',
+        indexPath: 'public/sketches/1_A/sketch/MySketch/index.html',
+      });
+    } finally { fs.rmSync(root, { recursive: true, force: true }); }
+  });
+
+  it('manifest entry omits sketchName and keeps the legacy indexPath when opdlFn does not report one', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-curation-'));
+    try {
+      const client = conflictClient([{ visualID: 1, title: 'A' }]);
+      const opdlFn = okOpdl();
+      const result = await downloadCuration({
+        curationId: 9, client, opdlFn, scaffoldFn: vi.fn(),
+        options: { outputDir: root, quiet: true },
+      });
+      expect(result.manifest[0].sketchName).toBeUndefined();
+      expect(result.manifest[0].indexPath).toBe('public/sketches/1_A/index.html');
+    } finally { fs.rmSync(root, { recursive: true, force: true }); }
+  });
+
+  describe('skipped-entry sketchName recovery from disk', () => {
+    const seedNestedSketch = (root, dir, sketchName, meta) => {
+      const sketchDir = path.join(root, 'public', 'sketches', dir, 'sketch', sketchName);
+      fs.mkdirSync(sketchDir, { recursive: true });
+      fs.writeFileSync(path.join(sketchDir, `${sketchName}.pde`), 'void setup() {}');
+      const metaDir = path.join(root, 'public', 'sketches', dir, 'metadata');
+      fs.mkdirSync(metaDir, { recursive: true });
+      if (meta) fs.writeFileSync(path.join(metaDir, 'metadata.json'), JSON.stringify(meta));
+    };
+
+    it('recovers sketchName when sketch/ has exactly one directory child', async () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-curation-'));
+      try {
+        seedNestedSketch(root, '1_A', 'MySketch', { visualID: 1, title: 'A', mode: 'pjs' });
+        const result = await downloadCuration({
+          curationId: 9, client: conflictClient([{ visualID: 1, title: 'A' }]),
+          opdlFn: okOpdl(), scaffoldFn: vi.fn(), onConflict: vi.fn().mockResolvedValue('skip'),
+          options: { outputDir: root, quiet: true },
+        });
+        expect(result.manifest[0]).toMatchObject({
+          sketchName: 'MySketch',
+          indexPath: 'public/sketches/1_A/sketch/MySketch/index.html',
+        });
+      } finally { fs.rmSync(root, { recursive: true, force: true }); }
+    });
+
+    it('omits sketchName when sketch/ is missing (legacy layout)', async () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-curation-'));
+      try {
+        seedExistingSketch(root, '1_A', { visualID: 1, title: 'A' });
+        const result = await downloadCuration({
+          curationId: 9, client: conflictClient([{ visualID: 1, title: 'A' }]),
+          opdlFn: okOpdl(), scaffoldFn: vi.fn(), onConflict: vi.fn().mockResolvedValue('skip'),
+          options: { outputDir: root, quiet: true },
+        });
+        expect(result.manifest[0].sketchName).toBeUndefined();
+        expect(result.manifest[0].indexPath).toBe('public/sketches/1_A/index.html');
+      } finally { fs.rmSync(root, { recursive: true, force: true }); }
+    });
+
+    it('omits sketchName when sketch/ has multiple directory children (ambiguous)', async () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-curation-'));
+      try {
+        seedNestedSketch(root, '1_A', 'One', { visualID: 1, title: 'A' });
+        fs.mkdirSync(path.join(root, 'public', 'sketches', '1_A', 'sketch', 'Two'), { recursive: true });
+        const result = await downloadCuration({
+          curationId: 9, client: conflictClient([{ visualID: 1, title: 'A' }]),
+          opdlFn: okOpdl(), scaffoldFn: vi.fn(), onConflict: vi.fn().mockResolvedValue('skip'),
+          options: { outputDir: root, quiet: true },
+        });
+        expect(result.manifest[0].sketchName).toBeUndefined();
+        expect(result.manifest[0].indexPath).toBe('public/sketches/1_A/index.html');
+      } finally { fs.rmSync(root, { recursive: true, force: true }); }
+    });
+
+    it('omits sketchName when sketch/ has no directory children (empty)', async () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-curation-'));
+      try {
+        fs.mkdirSync(path.join(root, 'public', 'sketches', '1_A', 'sketch'), { recursive: true });
+        fs.mkdirSync(path.join(root, 'public', 'sketches', '1_A', 'metadata'), { recursive: true });
+        fs.writeFileSync(path.join(root, 'public', 'sketches', '1_A', 'sketch', '.DS_Store'), '');
+        const result = await downloadCuration({
+          curationId: 9, client: conflictClient([{ visualID: 1, title: 'A' }]),
+          opdlFn: okOpdl(), scaffoldFn: vi.fn(), onConflict: vi.fn().mockResolvedValue('skip'),
+          options: { outputDir: root, quiet: true },
+        });
+        expect(result.manifest[0].sketchName).toBeUndefined();
+        expect(result.manifest[0].indexPath).toBe('public/sketches/1_A/index.html');
+      } finally { fs.rmSync(root, { recursive: true, force: true }); }
+    });
+  });
+
   it('continues after thrown and unavailable sketches', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-curation-'));
     try {

--- a/tests/download/downloader.test.mjs
+++ b/tests/download/downloader.test.mjs
@@ -315,6 +315,39 @@ describe('downloader', () => {
         expect(called).toBe(false);
         expect(fs.existsSync(path.join(result.sketchDir, 'data.json'))).toBe(true);
       });
+
+      it('rewrites code references to the collision-renamed asset (keep-both)', async () => {
+        // A code object named data.json and an uploaded asset data.json that
+        // the sketch code references: keep-both renames the asset to
+        // data_2.json, and the code reference must follow it — not keep
+        // pointing at data.json (which is now the code object, not the asset).
+        nock('https://example.com').get('/assets/data.json').reply(200, 'ASSET_BYTES');
+
+        const sketchInfo = {
+          sketchId: 12345,
+          title: 'Test',
+          author: 'Author',
+          codeParts: [
+            { title: 'sketch.js', code: 'loadJSON("data.json");' },
+            { title: 'data.json', code: '{"fromCodeObject":true}' },
+          ],
+          files: [{ name: 'data.json' }],
+          metadata: { mode: 'p5js', fileBase: 'https://example.com/assets' },
+        };
+
+        const result = await downloadSketch(sketchInfo, {
+          ...baseOptions,
+          onFilenameConflict: async () => 'keep-both',
+        });
+
+        // Asset landed under the deduped name; code object kept data.json.
+        expect(fs.readFileSync(path.join(result.sketchDir, 'data_2.json'), 'utf8')).toBe('ASSET_BYTES');
+        expect(fs.readFileSync(path.join(result.sketchDir, 'data.json'), 'utf8')).toBe('{"fromCodeObject":true}');
+        // The code reference points at the renamed asset, not the pre-collision name.
+        const js = fs.readFileSync(path.join(result.sketchDir, 'sketch.js'), 'utf8');
+        expect(js).toContain('loadJSON("data_2.json");');
+        expect(js).not.toContain('loadJSON("data.json");');
+      });
     });
 
     it('should skip assets when downloadAssets is false', async () => {
@@ -835,6 +868,35 @@ describe('downloader', () => {
 
       expect(result.sketchName).toBe('sketch');
       expect(fs.existsSync(path.join(result.sketchDir, 'sketch.pde'))).toBe(true);
+    });
+
+    it('does not let a dot-segment title ("..") escape the nested sketch directory', async () => {
+      const sketchInfo = {
+        sketchId: 1,
+        title: 'T',
+        author: 'A',
+        codeParts: [{ title: '..', code: 'void setup() {}' }],
+        files: [],
+        metadata: { mode: 'pjs', engineURL: 'https://example.com/processing.js' },
+      };
+
+      const result = await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: false,
+      });
+
+      // The sketch dir must stay nested — never collapse up to outputDir.
+      expect(result.sketchName).toBe('sketch');
+      expect(result.sketchDir).toBe(path.join(testDir, 'sketch', 'sketch'));
+      expect(path.resolve(result.sketchDir).startsWith(path.resolve(testDir, 'sketch') + path.sep)).toBe(true);
+      expect(fs.existsSync(path.join(result.sketchDir, 'sketch.pde'))).toBe(true);
+      // Bookkeeping must not be clobbered by code landing at outputDir.
+      expect(fs.existsSync(path.join(testDir, 'sketch.pde'))).toBe(false);
     });
 
     it('picks the main .pde when tab 0 is an explicit .js/index.html/.css', async () => {

--- a/tests/download/downloader.test.mjs
+++ b/tests/download/downloader.test.mjs
@@ -22,7 +22,7 @@ describe('downloader', () => {
   });
 
   describe('downloadSketch', () => {
-    it('should download sketch with code files', async () => {
+    it('should download sketch with code files under sketch/<name>/', async () => {
       const sketchInfo = {
         sketchId: 12345,
         title: 'Test Sketch',
@@ -49,11 +49,40 @@ describe('downloader', () => {
       });
 
       expect(result.outputDir).toBe(testDir);
-      expect(fs.existsSync(path.join(testDir, 'sketch.js'))).toBe(true);
-      expect(fs.existsSync(path.join(testDir, 'helpers.js'))).toBe(true);
+      expect(result.sketchName).toBe('sketch');
+      expect(result.sketchDir).toBe(path.join(testDir, 'sketch', 'sketch'));
+      expect(fs.existsSync(path.join(result.sketchDir, 'sketch.js'))).toBe(true);
+      expect(fs.existsSync(path.join(result.sketchDir, 'helpers.js'))).toBe(true);
 
-      const sketchContent = fs.readFileSync(path.join(testDir, 'sketch.js'), 'utf8');
+      const sketchContent = fs.readFileSync(path.join(result.sketchDir, 'sketch.js'), 'utf8');
       expect(sketchContent).toBe('console.log("test");');
+    });
+
+    it('keeps metadata/, LICENSE, OPENPROCESSING.md at the top-level outputDir', async () => {
+      const sketchInfo = {
+        sketchId: 12345,
+        title: 'Test',
+        author: 'Author',
+        codeParts: [{ title: 'sketch.js', code: 'x' }],
+        files: [],
+        metadata: { mode: 'p5js', license: 'by' },
+      };
+
+      await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: true,
+        downloadThumbnail: false,
+        createLicenseFile: true,
+        createOpMetadata: true,
+        addSourceComments: false,
+      });
+
+      expect(fs.existsSync(path.join(testDir, 'metadata', 'metadata.json'))).toBe(true);
+      expect(fs.existsSync(path.join(testDir, 'LICENSE'))).toBe(true);
+      expect(fs.existsSync(path.join(testDir, 'OPENPROCESSING.md'))).toBe(true);
+      // Not duplicated inside sketch/
+      expect(fs.existsSync(path.join(testDir, 'sketch', 'sketch', 'LICENSE'))).toBe(false);
     });
 
     it('should add source comments when enabled', async () => {
@@ -71,7 +100,7 @@ describe('downloader', () => {
         isFork: false,
       };
 
-      await downloadSketch(sketchInfo, {
+      const result = await downloadSketch(sketchInfo, {
         outputDir: testDir,
         addSourceComments: true,
         downloadAssets: false,
@@ -81,7 +110,7 @@ describe('downloader', () => {
         createOpMetadata: false,
       });
 
-      const content = fs.readFileSync(path.join(testDir, 'sketch.js'), 'utf8');
+      const content = fs.readFileSync(path.join(result.sketchDir, 'sketch.js'), 'utf8');
       expect(content).toContain('Downloaded with opdl');
       expect(content).toContain('Title: Test Sketch');
       expect(content).toContain('Author: Test Author');
@@ -101,7 +130,7 @@ describe('downloader', () => {
         isFork: false,
       };
 
-      await downloadSketch(sketchInfo, {
+      const result = await downloadSketch(sketchInfo, {
         outputDir: testDir,
         addSourceComments: true,
         downloadAssets: false,
@@ -111,7 +140,7 @@ describe('downloader', () => {
         createOpMetadata: false,
       });
 
-      const content = fs.readFileSync(path.join(testDir, 'sketch.js'), 'utf8');
+      const content = fs.readFileSync(path.join(result.sketchDir, 'sketch.js'), 'utf8');
       const matches = content.match(/Downloaded with opdl/g);
       expect(matches).toHaveLength(1);
     });
@@ -129,7 +158,7 @@ describe('downloader', () => {
         metadata: {},
       };
 
-      await downloadSketch(sketchInfo, {
+      const result = await downloadSketch(sketchInfo, {
         outputDir: testDir,
         downloadAssets: false,
         saveMetadata: false,
@@ -139,8 +168,8 @@ describe('downloader', () => {
         addSourceComments: false,
       });
 
-      expect(fs.existsSync(path.join(testDir, 'mysketch.js'))).toBe(true);
-      expect(fs.existsSync(path.join(testDir, 'filename.js'))).toBe(true);
+      expect(fs.existsSync(path.join(result.sketchDir, 'mysketch.js'))).toBe(true);
+      expect(fs.existsSync(path.join(result.sketchDir, 'filename.js'))).toBe(true);
     });
 
     it('should add .js extension to files without extension', async () => {
@@ -155,7 +184,7 @@ describe('downloader', () => {
         metadata: {},
       };
 
-      await downloadSketch(sketchInfo, {
+      const result = await downloadSketch(sketchInfo, {
         outputDir: testDir,
         downloadAssets: false,
         saveMetadata: false,
@@ -165,7 +194,8 @@ describe('downloader', () => {
         addSourceComments: false,
       });
 
-      expect(fs.existsSync(path.join(testDir, 'mysketch.js'))).toBe(true);
+      expect(fs.existsSync(path.join(result.sketchDir, 'mysketch.js'))).toBe(true);
+      expect(result.sketchName).toBe('mysketch');
     });
 
     it('should download assets when enabled', async () => {
@@ -186,7 +216,7 @@ describe('downloader', () => {
         },
       };
 
-      await downloadSketch(sketchInfo, {
+      const result = await downloadSketch(sketchInfo, {
         outputDir: testDir,
         downloadAssets: true,
         saveMetadata: false,
@@ -196,7 +226,7 @@ describe('downloader', () => {
         addSourceComments: false,
       });
 
-      expect(fs.existsSync(path.join(testDir, 'image.png'))).toBe(true);
+      expect(fs.existsSync(path.join(result.sketchDir, 'image.png'))).toBe(true);
     });
 
     describe('uploaded file vs code object name collision', () => {
@@ -228,14 +258,14 @@ describe('downloader', () => {
       it('keeps both by renaming the uploaded file (default)', async () => {
         nock('https://example.com').get('/assets/index.html').reply(200, uploadHtml);
 
-        await downloadSketch(makeSketchInfo(), {
+        const result = await downloadSketch(makeSketchInfo(), {
           ...baseOptions,
           onFilenameConflict: async () => 'keep-both',
         });
 
         // Code object keeps the canonical name; upload lands under index_2.html.
-        expect(fs.readFileSync(path.join(testDir, 'index.html'), 'utf8')).toBe(codeHtml);
-        expect(fs.readFileSync(path.join(testDir, 'index_2.html'), 'utf8')).toBe(uploadHtml);
+        expect(fs.readFileSync(path.join(result.sketchDir, 'index.html'), 'utf8')).toBe(codeHtml);
+        expect(fs.readFileSync(path.join(result.sketchDir, 'index_2.html'), 'utf8')).toBe(uploadHtml);
       });
 
       it('skips the uploaded file when asked', async () => {
@@ -243,13 +273,13 @@ describe('downloader', () => {
           .get('/assets/index.html')
           .reply(200, uploadHtml);
 
-        await downloadSketch(makeSketchInfo(), {
+        const result = await downloadSketch(makeSketchInfo(), {
           ...baseOptions,
           onFilenameConflict: async () => 'skip-upload',
         });
 
-        expect(fs.readFileSync(path.join(testDir, 'index.html'), 'utf8')).toBe(codeHtml);
-        expect(fs.existsSync(path.join(testDir, 'index_2.html'))).toBe(false);
+        expect(fs.readFileSync(path.join(result.sketchDir, 'index.html'), 'utf8')).toBe(codeHtml);
+        expect(fs.existsSync(path.join(result.sketchDir, 'index_2.html'))).toBe(false);
         // Skipped before fetching.
         expect(upload.isDone()).toBe(false);
         nock.cleanAll();
@@ -258,13 +288,13 @@ describe('downloader', () => {
       it('overwrites the code object when asked', async () => {
         nock('https://example.com').get('/assets/index.html').reply(200, uploadHtml);
 
-        await downloadSketch(makeSketchInfo(), {
+        const result = await downloadSketch(makeSketchInfo(), {
           ...baseOptions,
           onFilenameConflict: async () => 'overwrite-code',
         });
 
-        expect(fs.readFileSync(path.join(testDir, 'index.html'), 'utf8')).toBe(uploadHtml);
-        expect(fs.existsSync(path.join(testDir, 'index_2.html'))).toBe(false);
+        expect(fs.readFileSync(path.join(result.sketchDir, 'index.html'), 'utf8')).toBe(uploadHtml);
+        expect(fs.existsSync(path.join(result.sketchDir, 'index_2.html'))).toBe(false);
       });
 
       it('is not triggered when names do not collide', async () => {
@@ -274,7 +304,7 @@ describe('downloader', () => {
         const info = makeSketchInfo();
         info.files = [{ name: 'data.json' }];
 
-        await downloadSketch(info, {
+        const result = await downloadSketch(info, {
           ...baseOptions,
           onFilenameConflict: async () => {
             called = true;
@@ -283,7 +313,7 @@ describe('downloader', () => {
         });
 
         expect(called).toBe(false);
-        expect(fs.existsSync(path.join(testDir, 'data.json'))).toBe(true);
+        expect(fs.existsSync(path.join(result.sketchDir, 'data.json'))).toBe(true);
       });
     });
 
@@ -301,7 +331,7 @@ describe('downloader', () => {
         },
       };
 
-      await downloadSketch(sketchInfo, {
+      const result = await downloadSketch(sketchInfo, {
         outputDir: testDir,
         downloadAssets: false,
         saveMetadata: false,
@@ -311,7 +341,7 @@ describe('downloader', () => {
         addSourceComments: false,
       });
 
-      expect(fs.existsSync(path.join(testDir, 'image.png'))).toBe(false);
+      expect(fs.existsSync(path.join(result.sketchDir, 'image.png'))).toBe(false);
     });
 
     it('should save metadata when enabled', async () => {
@@ -392,7 +422,7 @@ describe('downloader', () => {
         },
       };
 
-      await downloadSketch(sketchInfo, {
+      const result = await downloadSketch(sketchInfo, {
         outputDir: testDir,
         downloadAssets: false,
         saveMetadata: false,
@@ -402,7 +432,7 @@ describe('downloader', () => {
         addSourceComments: false,
       });
 
-      expect(fs.existsSync(path.join(testDir, 'index.html'))).toBe(true);
+      expect(fs.existsSync(path.join(result.sketchDir, 'index.html'))).toBe(true);
     });
 
     it('should not generate index.html for html mode sketches', async () => {
@@ -419,7 +449,7 @@ describe('downloader', () => {
         },
       };
 
-      await downloadSketch(sketchInfo, {
+      const result = await downloadSketch(sketchInfo, {
         outputDir: testDir,
         downloadAssets: false,
         saveMetadata: false,
@@ -429,9 +459,9 @@ describe('downloader', () => {
         addSourceComments: false,
       });
 
-      const indexFiles = fs.readdirSync(testDir).filter(f => f === 'index.html');
+      const indexFiles = fs.readdirSync(result.sketchDir).filter(f => f === 'index.html');
       expect(indexFiles.length).toBe(1);
-      expect(fs.existsSync(path.join(testDir, 'style.css'))).toBe(false);
+      expect(fs.existsSync(path.join(result.sketchDir, 'style.css'))).toBe(false);
     });
 
     it('should not overwrite an existing index.html code part for non-html mode', async () => {
@@ -450,7 +480,7 @@ describe('downloader', () => {
         },
       };
 
-      await downloadSketch(sketchInfo, {
+      const result = await downloadSketch(sketchInfo, {
         outputDir: testDir,
         downloadAssets: false,
         saveMetadata: false,
@@ -460,9 +490,9 @@ describe('downloader', () => {
         addSourceComments: false,
       });
 
-      const content = fs.readFileSync(path.join(testDir, 'index.html'), 'utf8');
+      const content = fs.readFileSync(path.join(result.sketchDir, 'index.html'), 'utf8');
       expect(content).toBe(originalHtml);
-      expect(fs.existsSync(path.join(testDir, 'style.css'))).toBe(false);
+      expect(fs.existsSync(path.join(result.sketchDir, 'style.css'))).toBe(false);
     });
 
     it('should not write default style.css when a user CSS code part exists', async () => {
@@ -481,7 +511,7 @@ describe('downloader', () => {
         },
       };
 
-      await downloadSketch(sketchInfo, {
+      const result = await downloadSketch(sketchInfo, {
         outputDir: testDir,
         downloadAssets: false,
         saveMetadata: false,
@@ -491,10 +521,10 @@ describe('downloader', () => {
         addSourceComments: false,
       });
 
-      expect(fs.existsSync(path.join(testDir, 'index.html'))).toBe(true);
-      const themeContent = fs.readFileSync(path.join(testDir, 'theme.css'), 'utf8');
+      expect(fs.existsSync(path.join(result.sketchDir, 'index.html'))).toBe(true);
+      const themeContent = fs.readFileSync(path.join(result.sketchDir, 'theme.css'), 'utf8');
       expect(themeContent).toBe('body { color: red; }');
-      const html = fs.readFileSync(path.join(testDir, 'index.html'), 'utf8');
+      const html = fs.readFileSync(path.join(result.sketchDir, 'index.html'), 'utf8');
       expect(html).toContain('href="theme.css"');
       expect(html).not.toContain('href="style.css"');
     });
@@ -514,7 +544,7 @@ describe('downloader', () => {
         },
       };
 
-      await downloadSketch(sketchInfo, {
+      const result = await downloadSketch(sketchInfo, {
         outputDir: testDir,
         downloadAssets: false,
         saveMetadata: false,
@@ -524,7 +554,7 @@ describe('downloader', () => {
         addSourceComments: false,
       });
 
-      expect(fs.existsSync(path.join(testDir, 'style.css'))).toBe(true);
+      expect(fs.existsSync(path.join(result.sketchDir, 'style.css'))).toBe(true);
     });
 
     it('should create LICENSE file when enabled', async () => {
@@ -622,7 +652,7 @@ describe('downloader', () => {
         },
       };
 
-      await expect(downloadSketch(sketchInfo, {
+      const resultPromise = downloadSketch(sketchInfo, {
         outputDir: testDir,
         downloadAssets: true,
         quiet: true,
@@ -631,9 +661,11 @@ describe('downloader', () => {
         createLicenseFile: false,
         createOpMetadata: false,
         addSourceComments: false,
-      })).resolves.toBeDefined();
+      });
+      await expect(resultPromise).resolves.toBeDefined();
+      const result = await resultPromise;
 
-      expect(fs.existsSync(path.join(testDir, 'image.png'))).toBe(false);
+      expect(fs.existsSync(path.join(result.sketchDir, 'image.png'))).toBe(false);
     });
 
     it('should handle missing fileBase gracefully', async () => {
@@ -679,7 +711,7 @@ describe('downloader', () => {
         .get('/valid.png')
         .reply(200, Buffer.from('data'));
 
-      await expect(downloadSketch(sketchInfo, {
+      const resultPromise = downloadSketch(sketchInfo, {
         outputDir: testDir,
         downloadAssets: true,
         quiet: true,
@@ -688,9 +720,11 @@ describe('downloader', () => {
         createLicenseFile: false,
         createOpMetadata: false,
         addSourceComments: false,
-      })).resolves.toBeDefined();
+      });
+      await expect(resultPromise).resolves.toBeDefined();
+      const result = await resultPromise;
 
-      expect(fs.existsSync(path.join(testDir, 'valid.png'))).toBe(true);
+      expect(fs.existsSync(path.join(result.sketchDir, 'valid.png'))).toBe(true);
     });
   });
 
@@ -708,7 +742,7 @@ describe('downloader', () => {
         metadata: { mode: 'p5js' },
       };
 
-      await downloadSketch(sketchInfo, {
+      const result = await downloadSketch(sketchInfo, {
         outputDir: testDir,
         downloadAssets: false,
         saveMetadata: false,
@@ -718,8 +752,228 @@ describe('downloader', () => {
         addSourceComments: false,
       });
 
-      expect(fs.readFileSync(path.join(testDir, 'sketch.js'), 'utf8')).toBe('one');
-      expect(fs.readFileSync(path.join(testDir, 'sketch_2.js'), 'utf8')).toBe('two');
+      expect(fs.readFileSync(path.join(result.sketchDir, 'sketch.js'), 'utf8')).toBe('one');
+      expect(fs.readFileSync(path.join(result.sketchDir, 'sketch_2.js'), 'utf8')).toBe('two');
+    });
+  });
+
+  describe('pjs sketches', () => {
+    it('writes .pde tabs, names the folder after the main .pde, no sketch.properties', async () => {
+      const sketchInfo = {
+        sketchId: 1,
+        title: 'T',
+        author: 'A',
+        codeParts: [
+          { title: 'MySketch', code: 'void setup() {}' },
+        ],
+        files: [],
+        metadata: { mode: 'pjs', engineURL: 'https://example.com/processing.js' },
+      };
+
+      const result = await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: false,
+      });
+
+      expect(result.sketchName).toBe('MySketch');
+      expect(result.sketchDir).toBe(path.join(testDir, 'sketch', 'MySketch'));
+      expect(fs.existsSync(path.join(result.sketchDir, 'MySketch.pde'))).toBe(true);
+      expect(fs.existsSync(path.join(result.sketchDir, 'sketch.properties'))).toBe(false);
+
+      const html = fs.readFileSync(path.join(result.sketchDir, 'index.html'), 'utf8');
+      expect(html).toContain('data-processing-sources="MySketch.pde"');
+      expect(html).not.toContain('<script src="MySketch.pde">');
+    });
+
+    it('accepts the processingjs alias identically to pjs', async () => {
+      const sketchInfo = {
+        sketchId: 1,
+        title: 'T',
+        author: 'A',
+        codeParts: [{ title: 'Main', code: 'void setup() {}' }],
+        files: [],
+        metadata: { mode: 'processingjs', engineURL: 'https://example.com/processing.js' },
+      };
+
+      const result = await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: false,
+      });
+
+      expect(fs.existsSync(path.join(result.sketchDir, 'Main.pde'))).toBe(true);
+    });
+
+    it('falls back to sketch.pde when the title sanitizes to nothing', async () => {
+      const sketchInfo = {
+        sketchId: 1,
+        title: 'T',
+        author: 'A',
+        codeParts: [{ title: '***', code: 'void setup() {}' }],
+        files: [],
+        metadata: { mode: 'pjs', engineURL: 'https://example.com/processing.js' },
+      };
+
+      const result = await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: false,
+      });
+
+      expect(result.sketchName).toBe('sketch');
+      expect(fs.existsSync(path.join(result.sketchDir, 'sketch.pde'))).toBe(true);
+    });
+
+    it('picks the main .pde when tab 0 is an explicit .js/index.html/.css', async () => {
+      const sketchInfo = {
+        sketchId: 1,
+        title: 'T',
+        author: 'A',
+        codeParts: [
+          { title: 'helper.js', code: 'x' },
+          { title: 'Main', code: 'void setup() {}' },
+        ],
+        files: [],
+        metadata: { mode: 'pjs', engineURL: 'https://example.com/processing.js' },
+      };
+
+      const result = await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: false,
+      });
+
+      expect(result.sketchName).toBe('Main');
+      const html = fs.readFileSync(path.join(result.sketchDir, 'index.html'), 'utf8');
+      expect(html).toContain('<script src="helper.js"></script>');
+      expect(html).toContain('data-processing-sources="Main.pde"');
+    });
+
+    it('lists all .pde files in tab order on the canvas', async () => {
+      const sketchInfo = {
+        sketchId: 1,
+        title: 'T',
+        author: 'A',
+        codeParts: [
+          { title: 'a', code: 'void setup() {}' },
+          { title: 'b', code: 'void draw() {}' },
+        ],
+        files: [],
+        metadata: { mode: 'pjs', engineURL: 'https://example.com/processing.js' },
+      };
+
+      const result = await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: false,
+      });
+
+      const html = fs.readFileSync(path.join(result.sketchDir, 'index.html'), 'utf8');
+      expect(html).toContain('data-processing-sources="a.pde b.pde"');
+    });
+
+    it('falls back to plain <script src> wiring with a warning when there are no .pde tabs', async () => {
+      const sketchInfo = {
+        sketchId: 1,
+        title: 'T',
+        author: 'A',
+        codeParts: [{ title: 'sketch.js', code: 'x' }],
+        files: [],
+        metadata: { mode: 'pjs', engineURL: 'https://example.com/processing.js' },
+      };
+
+      const result = await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: false,
+      });
+
+      expect(result.sketchName).toBe('sketch');
+      const html = fs.readFileSync(path.join(result.sketchDir, 'index.html'), 'utf8');
+      expect(html).toContain('<script src="sketch.js"></script>');
+      expect(html).not.toContain('data-processing-sources');
+    });
+
+    it('adds .pde attribution comments (C-style)', async () => {
+      const sketchInfo = {
+        sketchId: 42,
+        title: 'Test Sketch',
+        author: 'Author',
+        codeParts: [{ title: 'Main', code: 'void setup() {}' }],
+        files: [],
+        metadata: { mode: 'pjs', engineURL: 'https://example.com/processing.js' },
+      };
+
+      const result = await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: true,
+      });
+
+      const content = fs.readFileSync(path.join(result.sketchDir, 'Main.pde'), 'utf8');
+      expect(content).toContain('/*');
+      expect(content).toContain('Downloaded with opdl');
+    });
+  });
+
+  describe('prepass collision handling', () => {
+    it('two tabs resolving to the same pde name dedupe consistently between the predicted list and disk', async () => {
+      const sketchInfo = {
+        sketchId: 1,
+        title: 'T',
+        author: 'A',
+        codeParts: [
+          { title: 'Main', code: 'void setup() {}' },
+          { title: 'Main', code: 'void draw() {}' },
+        ],
+        files: [],
+        metadata: { mode: 'pjs', engineURL: 'https://example.com/processing.js' },
+      };
+
+      const result = await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: false,
+      });
+
+      expect(result.sketchName).toBe('Main');
+      expect(fs.readFileSync(path.join(result.sketchDir, 'Main.pde'), 'utf8')).toContain('setup');
+      expect(fs.readFileSync(path.join(result.sketchDir, 'Main_2.pde'), 'utf8')).toContain('draw');
+      const html = fs.readFileSync(path.join(result.sketchDir, 'index.html'), 'utf8');
+      expect(html).toContain('data-processing-sources="Main.pde Main_2.pde"');
     });
   });
 
@@ -753,6 +1007,7 @@ describe('downloader', () => {
         addSourceComments: false,
       });
 
+      // Tutorial bundle keeps its current layout at outputDir, out of scope for nesting.
       expect(fs.existsSync(path.join(testDir, 'tutorial/page_1/README.md'))).toBe(true);
       expect(fs.readFileSync(path.join(testDir, 'tutorial/page_1/mySketch.js'), 'utf8')).toBe('page code');
     });
@@ -778,6 +1033,37 @@ describe('downloader', () => {
       });
 
       expect(fs.existsSync(path.join(testDir, 'tutorial'))).toBe(false);
+    });
+  });
+
+  describe('return contract', () => {
+    it('returns { outputDir, metadataDir, sketchDir, sketchName, codeFiles }', async () => {
+      const sketchInfo = {
+        sketchId: 1,
+        title: 'T',
+        author: 'A',
+        codeParts: [{ title: 'sketch.js', code: 'x' }],
+        files: [],
+        metadata: { mode: 'p5js' },
+      };
+
+      const result = await downloadSketch(sketchInfo, {
+        outputDir: testDir,
+        downloadAssets: false,
+        saveMetadata: false,
+        downloadThumbnail: false,
+        createLicenseFile: false,
+        createOpMetadata: false,
+        addSourceComments: false,
+      });
+
+      expect(result).toMatchObject({
+        outputDir: testDir,
+        metadataDir: path.join(testDir, 'metadata'),
+        sketchDir: path.join(testDir, 'sketch', 'sketch'),
+        sketchName: 'sketch',
+      });
+      expect(Array.isArray(result.codeFiles)).toBe(true);
     });
   });
 });

--- a/tests/download/galleryScaffolder.test.mjs
+++ b/tests/download/galleryScaffolder.test.mjs
@@ -24,6 +24,25 @@ describe('scaffoldGalleryProject', () => {
     } finally { fs.rmSync(root, { recursive: true, force: true }); }
   });
 
+  it('sketchUrl() targets the nested sketch/<name>/ path when sketchName is present, else the legacy path', async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-gallery-'));
+    try {
+      await scaffoldGalleryProject(root, { curationId: 5, curationTitle: 'Gallery', quiet: true });
+      const js = fs.readFileSync(path.join(root, 'main.js'), 'utf8');
+      const match = js.match(/function sketchUrl\(project\) \{[\s\S]*?\n\}/);
+      expect(match).toBeTruthy();
+      const sketchUrl = new Function(
+        'encodeURIComponent',
+        `${match[0]}\nreturn sketchUrl;`
+      )(encodeURIComponent);
+
+      expect(sketchUrl({ dir: '1_A B', sketchName: 'My Sketch' }))
+        .toBe('./sketches/1_A%20B/sketch/My%20Sketch/index.html');
+      expect(sketchUrl({ dir: '1_A B' }))
+        .toBe('./sketches/1_A%20B/index.html');
+    } finally { fs.rmSync(root, { recursive: true, force: true }); }
+  });
+
   it('accepts an authored HTML, CSS, and JavaScript template directory', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-gallery-'));
     const templates = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-gallery-template-'));

--- a/tests/download/htmlGenerator.test.mjs
+++ b/tests/download/htmlGenerator.test.mjs
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import { generateIndexHtml, DEFAULT_STYLESHEET, CENTERED_STYLESHEET } from '../../src/download/htmlGenerator';
@@ -333,6 +333,115 @@ describe('htmlGenerator', () => {
 
       expect(fs.existsSync(path.join(testDir, 'index.html'))).toBe(false);
       expect(fs.existsSync(path.join(testDir, 'style.css'))).toBe(false);
+    });
+
+    it('pjs: renders a canvas with data-processing-sources for .pde tabs, no script src for .pde', () => {
+      const metadata = {
+        engineURL: 'https://example.com/processing.js',
+        mode: 'pjs',
+      };
+      const codeParts = [
+        { title: 'MySketch.pde' },
+      ];
+
+      generateIndexHtml(metadata, codeParts, testDir);
+      const content = fs.readFileSync(path.join(testDir, 'index.html'), 'utf8');
+
+      expect(content).toContain('<canvas data-processing-sources="MySketch.pde"></canvas>');
+      expect(content).not.toContain('<script src="MySketch.pde">');
+    });
+
+    it('pjs: lists multiple .pde tabs on the canvas in tab order', () => {
+      const metadata = {
+        engineURL: 'https://example.com/processing.js',
+        mode: 'pjs',
+      };
+      const codeParts = [
+        { title: 'a.pde' },
+        { title: 'b.pde' },
+      ];
+
+      generateIndexHtml(metadata, codeParts, testDir);
+      const content = fs.readFileSync(path.join(testDir, 'index.html'), 'utf8');
+
+      expect(content).toContain('data-processing-sources="a.pde b.pde"');
+    });
+
+    it('pjs: treats the processingjs alias identically to pjs', () => {
+      const metadata = {
+        engineURL: 'https://example.com/processing.js',
+        mode: 'processingjs',
+      };
+      const codeParts = [{ title: 'Main.pde' }];
+
+      generateIndexHtml(metadata, codeParts, testDir);
+      const content = fs.readFileSync(path.join(testDir, 'index.html'), 'utf8');
+
+      expect(content).toContain('data-processing-sources="Main.pde"');
+    });
+
+    it('pjs: excludes .js helper tabs from the canvas but keeps them as <script src>', () => {
+      const metadata = {
+        engineURL: 'https://example.com/processing.js',
+        mode: 'pjs',
+      };
+      const codeParts = [
+        { title: 'Main.pde' },
+        { title: 'helper.js' },
+      ];
+
+      generateIndexHtml(metadata, codeParts, testDir);
+      const content = fs.readFileSync(path.join(testDir, 'index.html'), 'utf8');
+
+      expect(content).toContain('data-processing-sources="Main.pde"');
+      expect(content).not.toContain('data-processing-sources="Main.pde helper.js"');
+      expect(content).toContain('<script src="helper.js"></script>');
+    });
+
+    it('pjs: falls back to plain <script src> wiring and warns when there are no .pde tabs', () => {
+      const metadata = {
+        engineURL: 'https://example.com/processing.js',
+        mode: 'pjs',
+      };
+      const codeParts = [{ title: 'sketch.js' }];
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      generateIndexHtml(metadata, codeParts, testDir);
+      const content = fs.readFileSync(path.join(testDir, 'index.html'), 'utf8');
+
+      expect(content).not.toContain('data-processing-sources');
+      expect(content).toContain('<script src="sketch.js"></script>');
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('pjs: an existing index.html code object still short-circuits (early return)', () => {
+      const metadata = {
+        engineURL: 'https://example.com/processing.js',
+        mode: 'pjs',
+      };
+      const codeParts = [
+        { title: 'index.html' },
+        { title: 'Main.pde' },
+      ];
+
+      generateIndexHtml(metadata, codeParts, testDir);
+
+      expect(fs.existsSync(path.join(testDir, 'index.html'))).toBe(false);
+    });
+
+    it('non-pjs modes are unaffected by the pjs canvas branch', () => {
+      const metadata = {
+        engineURL: 'https://example.com/p5.js',
+        mode: 'p5js',
+      };
+      const codeParts = [{ title: 'sketch.js' }];
+
+      generateIndexHtml(metadata, codeParts, testDir);
+      const content = fs.readFileSync(path.join(testDir, 'index.html'), 'utf8');
+
+      expect(content).not.toContain('data-processing-sources');
+      expect(content).toContain('<script src="sketch.js"></script>');
     });
 
     it('should filter out code parts without titles', () => {

--- a/tests/download/viteScaffolder.test.mjs
+++ b/tests/download/viteScaffolder.test.mjs
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
+import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
-import { scaffoldViteProject } from '../../src/download/viteScaffolder.js';
+import { scaffoldViteProject, buildCompletionMessage } from '../../src/download/viteScaffolder.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -394,4 +396,188 @@ describe('viteScaffolder', () => {
       expect(runDevServerFn).toHaveBeenCalledWith(testDir, { vite: true, quiet: true });
     });
   });
+
+  describe('buildCompletionMessage', () => {
+    it('uses a relative path shell-quoted for a cd-and-run command', () => {
+      const message = buildCompletionMessage(testDir);
+      const relative = path.relative(process.cwd(), testDir);
+      expect(message).toContain(`cd '${relative}'`);
+      expect(message).toContain('npm run dev');
+    });
+
+    it('escapes single quotes in a path so the command stays runnable', () => {
+      const weirdDir = path.join(testDir, "it's a dir");
+      const message = buildCompletionMessage(weirdDir);
+      const relative = path.relative(process.cwd(), weirdDir);
+      expect(message).toContain(`cd '${relative.replace(/'/g, "'\\''")}'`);
+    });
+  });
+
+  describe('pjs scaffold (--vite)', () => {
+    it('moves nothing: .pde, .js helper, .css, and a downloaded image stay at the project root', async () => {
+      const pdeFile = path.join(testDir, 'MySketch.pde');
+      const jsHelper = path.join(testDir, 'helper.js');
+      const cssFile = path.join(testDir, 'style.css');
+      const imageFile = path.join(testDir, 'image.png');
+      const envFile = path.join(testDir, '.env');
+      fs.writeFileSync(pdeFile, 'void setup() {}', 'utf8');
+      fs.writeFileSync(jsHelper, 'function helper() {}', 'utf8');
+      fs.writeFileSync(cssFile, 'body { margin: 0; }', 'utf8');
+      fs.writeFileSync(imageFile, 'fake image data', 'utf8');
+      fs.writeFileSync(envFile, 'SECRET=1', 'utf8');
+
+      const indexHtmlPath = path.join(testDir, 'index.html');
+      const originalHtml = `<!DOCTYPE html><html><head><script src="https://openprocessing.org/openprocessing_sketch.js"></script></head><body>\n<canvas data-processing-sources="MySketch.pde"></canvas>\n</body></html>`;
+      fs.writeFileSync(indexHtmlPath, originalHtml, 'utf8');
+
+      const sketchInfo = { sketchId: 12345, metadata: { mode: 'pjs' } };
+
+      await scaffoldViteProject(testDir, sketchInfo, {
+        codeFiles: [pdeFile, jsHelper, cssFile],
+        runtimeFiles: ['MySketch.pde', 'helper.js', 'style.css', 'image.png'],
+        quiet: true,
+      });
+
+      // Nothing moved.
+      expect(fs.existsSync(path.join(testDir, 'src'))).toBe(false);
+      expect(fs.existsSync(path.join(testDir, 'public'))).toBe(false);
+      expect(fs.existsSync(pdeFile)).toBe(true);
+      expect(fs.existsSync(jsHelper)).toBe(true);
+      expect(fs.existsSync(cssFile)).toBe(true);
+      expect(fs.existsSync(imageFile)).toBe(true);
+
+      // index.html unrewritten.
+      expect(fs.readFileSync(indexHtmlPath, 'utf8')).toBe(originalHtml);
+
+      // vite.config.js contains exactly the allowlisted runtime files, and
+      // the planted .env is not in the allowlist.
+      const viteConfig = fs.readFileSync(path.join(testDir, 'vite.config.js'), 'utf8');
+      const match = viteConfig.match(/const runtimeFiles = (\[[^\]]*\]);/);
+      expect(match).toBeTruthy();
+      const runtimeFiles = JSON.parse(match[1]);
+      expect(runtimeFiles.sort()).toEqual(['MySketch.pde', 'helper.js', 'image.png', 'style.css'].sort());
+      expect(runtimeFiles).not.toContain('.env');
+      expect(runtimeFiles).not.toContain('index.html');
+    });
+
+    it('resolves an asset with quotes/backticks to its safe resolveAssetFileName equivalent in the allowlist', async () => {
+      const pdeFile = path.join(testDir, 'Main.pde');
+      fs.writeFileSync(pdeFile, 'void setup() {}', 'utf8');
+      const safeAssetName = 'asset_1.png';
+      fs.writeFileSync(path.join(testDir, safeAssetName), 'img', 'utf8');
+
+      const sketchInfo = { sketchId: 1, metadata: { mode: 'pjs' } };
+
+      await scaffoldViteProject(testDir, sketchInfo, {
+        codeFiles: [pdeFile],
+        runtimeFiles: ['Main.pde', safeAssetName],
+        quiet: true,
+      });
+
+      const viteConfig = fs.readFileSync(path.join(testDir, 'vite.config.js'), 'utf8');
+      expect(viteConfig).toContain(`"${safeAssetName}"`);
+      // The generated config must stay syntactically valid.
+      expect(() => new Function(
+        viteConfig
+          .replace(/^import.*$/gm, '')
+          .replace(/export default defineConfig\(/, '(')
+      )).not.toThrow();
+    });
+
+    it('excludes unsafe/duplicate/index.html entries from the allowlist even if passed in runtimeFiles', async () => {
+      const pdeFile = path.join(testDir, 'Main.pde');
+      fs.writeFileSync(pdeFile, 'void setup() {}', 'utf8');
+
+      const sketchInfo = { sketchId: 1, metadata: { mode: 'pjs' } };
+
+      await scaffoldViteProject(testDir, sketchInfo, {
+        codeFiles: [pdeFile],
+        runtimeFiles: ['Main.pde', 'Main.pde', 'index.html', '../evil.js', '/abs/evil.js'],
+        quiet: true,
+      });
+
+      const viteConfig = fs.readFileSync(path.join(testDir, 'vite.config.js'), 'utf8');
+      const match = viteConfig.match(/const runtimeFiles = (\[[^\]]*\]);/);
+      expect(match).toBeTruthy();
+      const runtimeFiles = JSON.parse(match[1]);
+      expect(runtimeFiles).toEqual(['Main.pde']);
+    });
+
+    it('completion message prints the full shell-quoted cd path for a pjs project', async () => {
+      const pdeFile = path.join(testDir, 'Main.pde');
+      fs.writeFileSync(pdeFile, 'void setup() {}', 'utf8');
+
+      const sketchInfo = { sketchId: 1, metadata: { mode: 'pjs' } };
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      try {
+        await scaffoldViteProject(testDir, sketchInfo, {
+          codeFiles: [pdeFile],
+          runtimeFiles: ['Main.pde'],
+          quiet: true,
+        });
+      } finally {
+        logSpy.mockRestore();
+      }
+      // In quiet mode npm install is skipped, so assert package.json + config exist
+      // (the completion message itself is covered by the buildCompletionMessage suite).
+      expect(fs.existsSync(path.join(testDir, 'package.json'))).toBe(true);
+      expect(fs.existsSync(path.join(testDir, 'vite.config.js'))).toBe(true);
+    });
+
+    it('p5js vite still scaffolds rooted at the given sketchDir (regression: pjs branch must not affect it)', async () => {
+      const codeFile = path.join(testDir, 'sketch.js');
+      fs.writeFileSync(codeFile, 'function setup() {}', 'utf8');
+
+      const sketchInfo = { sketchId: 1, metadata: { mode: 'p5js' } };
+      await scaffoldViteProject(testDir, sketchInfo, {
+        codeFiles: [codeFile],
+        quiet: true,
+      });
+
+      expect(fs.existsSync(path.join(testDir, 'src', 'sketch.js'))).toBe(true);
+      expect(fs.existsSync(path.join(testDir, 'package.json'))).toBe(true);
+    });
+  });
+});
+
+// Opt-in only (npm install + a real Vite build are slow/network-dependent),
+// so the default `npm test` stays deterministic. Run with:
+//   OPDL_INTEGRATION=1 npm test
+describe.skipIf(process.env.OPDL_INTEGRATION !== '1')('pjs Vite build integration', () => {
+  it('npm run build copies index.html + every .pde + the .js helper + the image into dist/, and excludes .env', async () => {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'opdl-vite-build-'));
+    try {
+      const pdeFile = path.join(projectDir, 'MySketch.pde');
+      const jsHelper = path.join(projectDir, 'helper.js');
+      const imageFile = path.join(projectDir, 'image.png');
+      fs.writeFileSync(pdeFile, 'void setup() { size(100, 100); }', 'utf8');
+      fs.writeFileSync(jsHelper, 'function helper() {}', 'utf8');
+      fs.writeFileSync(imageFile, 'fake image data', 'utf8');
+      fs.writeFileSync(path.join(projectDir, '.env'), 'SECRET=1', 'utf8');
+      fs.writeFileSync(
+        path.join(projectDir, 'index.html'),
+        '<!DOCTYPE html><html><head><script src="https://openprocessing.org/openprocessing_sketch.js"></script></head><body>\n<canvas data-processing-sources="MySketch.pde"></canvas>\n</body></html>',
+        'utf8'
+      );
+
+      const sketchInfo = { sketchId: 999, metadata: { mode: 'pjs' } };
+      await scaffoldViteProject(projectDir, sketchInfo, {
+        codeFiles: [pdeFile, jsHelper],
+        runtimeFiles: ['MySketch.pde', 'helper.js', 'image.png'],
+        quiet: true,
+      });
+
+      execFileSync('npm', ['install'], { cwd: projectDir, stdio: 'inherit' });
+      execFileSync('npm', ['run', 'build'], { cwd: projectDir, stdio: 'inherit' });
+
+      const distDir = path.join(projectDir, 'dist');
+      expect(fs.existsSync(path.join(distDir, 'index.html'))).toBe(true);
+      expect(fs.existsSync(path.join(distDir, 'MySketch.pde'))).toBe(true);
+      expect(fs.existsSync(path.join(distDir, 'helper.js'))).toBe(true);
+      expect(fs.existsSync(path.join(distDir, 'image.png'))).toBe(true);
+      expect(fs.existsSync(path.join(distDir, '.env'))).toBe(false);
+    } finally {
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  }, 180000);
 });

--- a/tests/index.test.mjs
+++ b/tests/index.test.mjs
@@ -26,6 +26,8 @@ describe('opdl (integration)', () => {
 
     expect(result.success).toBe(false);
     expect(result.sketchInfo.error).toBe('Invalid sketch ID');
+    expect(result.sketchName).toBeNull();
+    expect(result.sketchPath).toBeNull();
   });
 
   it('should handle sketch with API errors', async () => {
@@ -51,6 +53,8 @@ describe('opdl (integration)', () => {
 
     expect(result.sketchInfo.error).toBeTruthy();
     expect(result.sketchInfo.error).toContain('Not found');
+    expect(result.sketchName).toBeNull();
+    expect(result.sketchPath).toBeNull();
   });
 
   it('should handle hidden code sketches', async () => {
@@ -89,6 +93,8 @@ describe('opdl (integration)', () => {
     expect(result.sketchInfo.title).toBe('Hidden Sketch');
     expect(result.sketchInfo.author).toBe('Test Author');
     expect(result.outputPath).toBeNull();
+    expect(result.sketchName).toBeNull();
+    expect(result.sketchPath).toBeNull();
   });
 
   it('should successfully download a p5js sketch', async () => {
@@ -138,9 +144,11 @@ describe('opdl (integration)', () => {
     expect(result.sketchInfo.mode).toBe('p5js');
     expect(result.sketchInfo.isFork).toBe(false);
     expect(result.outputPath).toBe(testDir);
+    expect(result.sketchName).toBe('sketch');
+    expect(result.sketchPath).toBe(path.join(testDir, 'sketch', 'sketch'));
 
-    expect(fs.existsSync(path.join(testDir, 'sketch.js'))).toBe(true);
-    expect(fs.existsSync(path.join(testDir, 'index.html'))).toBe(true);
+    expect(fs.existsSync(path.join(result.sketchPath, 'sketch.js'))).toBe(true);
+    expect(fs.existsSync(path.join(result.sketchPath, 'index.html'))).toBe(true);
     expect(fs.existsSync(path.join(testDir, 'LICENSE'))).toBe(true);
     expect(fs.existsSync(path.join(testDir, 'OPENPROCESSING.md'))).toBe(true);
   });
@@ -185,7 +193,12 @@ describe('opdl (integration)', () => {
 
     expect(result.success).toBe(true);
     expect(result.sketchInfo.mode).toBe('processingjs');
-    expect(fs.existsSync(path.join(testDir, 'mysketch.js'))).toBe(true);
+    expect(result.sketchName).toBe('mysketch');
+    expect(fs.existsSync(path.join(result.sketchPath, 'mysketch.pde'))).toBe(true);
+    expect(fs.existsSync(path.join(result.sketchPath, 'sketch.properties'))).toBe(false);
+
+    const html = fs.readFileSync(path.join(result.sketchPath, 'index.html'), 'utf8');
+    expect(html).toContain('data-processing-sources="mysketch.pde"');
   });
 
   it('should handle fork sketches', async () => {
@@ -241,7 +254,7 @@ describe('opdl (integration)', () => {
     expect(result.success).toBe(true);
     expect(result.sketchInfo.isFork).toBe(true);
 
-    const codeContent = fs.readFileSync(path.join(testDir, 'sketch.js'), 'utf8');
+    const codeContent = fs.readFileSync(path.join(result.sketchPath, 'sketch.js'), 'utf8');
     expect(codeContent).toContain('Forked from: Original Sketch by Original Author');
 
     const opMd = fs.readFileSync(path.join(testDir, 'OPENPROCESSING.md'), 'utf8');
@@ -293,7 +306,7 @@ describe('opdl (integration)', () => {
     });
 
     expect(result.success).toBe(true);
-    expect(fs.existsSync(path.join(testDir, 'image.png'))).toBe(true);
+    expect(fs.existsSync(path.join(result.sketchPath, 'image.png'))).toBe(true);
   });
 
   it('should use default options when none provided', async () => {
@@ -337,13 +350,13 @@ describe('opdl (integration)', () => {
 
     const outputPath = result.outputPath;
     expect(fs.existsSync(outputPath)).toBe(true);
-    expect(fs.existsSync(path.join(outputPath, 'sketch.js'))).toBe(true);
+    expect(fs.existsSync(path.join(result.sketchPath, 'sketch.js'))).toBe(true);
     expect(fs.existsSync(path.join(outputPath, 'LICENSE'))).toBe(true);
     expect(fs.existsSync(path.join(outputPath, 'OPENPROCESSING.md'))).toBe(true);
     expect(fs.existsSync(path.join(outputPath, 'metadata', 'metadata.json'))).toBe(true);
     expect(fs.existsSync(path.join(outputPath, 'metadata', 'thumbnail.jpg'))).toBe(true);
 
-    const codeContent = fs.readFileSync(path.join(outputPath, 'sketch.js'), 'utf8');
+    const codeContent = fs.readFileSync(path.join(result.sketchPath, 'sketch.js'), 'utf8');
     expect(codeContent).toContain('Downloaded with opdl');
 
     if (fs.existsSync(outputPath)) {
@@ -440,7 +453,7 @@ describe('opdl (integration)', () => {
 
     expect(result.success).toBe(true);
 
-    const htmlFiles = fs.readdirSync(testDir).filter(f => f === 'index.html');
+    const htmlFiles = fs.readdirSync(result.sketchPath).filter(f => f === 'index.html');
     expect(htmlFiles.length).toBe(1);
   });
 
@@ -486,13 +499,13 @@ describe('opdl (integration)', () => {
     });
 
     expect(result.success).toBe(true);
-    expect(fs.existsSync(path.join(testDir, 'sketch.js'))).toBe(true);
+    expect(fs.existsSync(path.join(result.sketchPath, 'sketch.js'))).toBe(true);
     expect(fs.existsSync(path.join(testDir, 'LICENSE'))).toBe(false);
     expect(fs.existsSync(path.join(testDir, 'OPENPROCESSING.md'))).toBe(false);
     expect(fs.existsSync(path.join(testDir, 'metadata', 'metadata.json'))).toBe(false);
     expect(fs.existsSync(path.join(testDir, 'metadata', 'thumbnail.jpg'))).toBe(false);
 
-    const codeContent = fs.readFileSync(path.join(testDir, 'sketch.js'), 'utf8');
+    const codeContent = fs.readFileSync(path.join(result.sketchPath, 'sketch.js'), 'utf8');
     expect(codeContent).not.toContain('Downloaded with opdl');
   });
 

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -4,6 +4,7 @@ import path from 'path';
 import {
   ensureDirectoryExists,
   sanitizeFilename,
+  resolveAssetFileName,
   buildAssetRenameMap,
   rewriteAssetReferences,
   resolveAssetUrl,
@@ -49,6 +50,40 @@ describe('utils', () => {
     });
   });
 
+  describe('resolveAssetFileName', () => {
+    it('passes normal names through sanitized', () => {
+      expect(resolveAssetFileName('image.png', 0)).toBe('image.png');
+      expect(resolveAssetFileName('Bottle slide.m4a', 3)).toBe('Bottle_slide.m4a');
+    });
+
+    it('falls back to asset_<n> when the original sanitizes to an empty string', () => {
+      expect(resolveAssetFileName('***', 0)).toBe('asset_1');
+    });
+
+    it('strips quotes/backticks like sanitizeFilename does elsewhere', () => {
+      const result = resolveAssetFileName('weird`"name.png', 4);
+      expect(result).toBe('weirdname.png');
+    });
+
+    it('falls back to asset_<n>.<ext> when the sanitized result is a bare extension with no stem', () => {
+      // '???.png' sanitizes to '.png' — sanitization-stable but has no usable
+      // stem, so it would land on disk as a hidden dotfile, not a real name.
+      const result = resolveAssetFileName('???.png', 2);
+      expect(result).toBe('asset_3.png');
+    });
+
+    it('drops the extension when it is itself unsalvageable', () => {
+      const result = resolveAssetFileName('file.`"', 0);
+      expect(result).toBe('asset_1');
+    });
+
+    it('never returns the raw unsanitized original as a fallback', () => {
+      const result = resolveAssetFileName('a"b`c.png', 1);
+      expect(result).not.toBe('a"b`c.png');
+      expect(sanitizeFilename(result)).toBe(result);
+    });
+  });
+
   describe('buildAssetRenameMap', () => {
     it('includes only files whose sanitized name differs', () => {
       const files = [
@@ -58,6 +93,19 @@ describe('utils', () => {
       ];
       expect(buildAssetRenameMap(files)).toEqual([
         { original: 'Bottle slide.m4a', sanitized: 'Bottle_slide.m4a' },
+      ]);
+    });
+
+    it('agrees with resolveAssetFileName by index for quote/backtick-bearing names', () => {
+      const files = [
+        { name: 'a"b`c.png' },
+        { name: 'plain.png' },
+        { name: '???.jpg' },
+      ];
+      const renames = buildAssetRenameMap(files);
+      expect(renames).toEqual([
+        { original: 'a"b`c.png', sanitized: resolveAssetFileName('a"b`c.png', 0) },
+        { original: '???.jpg', sanitized: resolveAssetFileName('???.jpg', 2) },
       ]);
     });
 


### PR DESCRIPTION
Initial implementation. Plan below by Claude Fable 5 + GPT 5.6 Sol review. Implemented by Sonnet 5. 

---

# Plan: pjs dual-purpose downloads + nested sketch folder layout (rev 6)

## Context

OpenProcessing "pjs" (Processing.js) sketches are Processing (Java-like) code, not JavaScript. Today
pjs tabs are written as `.js` ([codeFileWriter.js](src/download/codeFileWriter.js)) and
[htmlGenerator.js:58-68](src/download/htmlGenerator.js#L58-L68) emits a plain `<script src="x.js">`, so
the browser runs Processing code as JS and nothing renders — and there's no runnable local Processing
sketch either.

The fix (per the archived Processing.js tutorial): write tabs as `.pde` and reference them from a
canvas via `data-processing-sources`. The user also wants a cleaner on-disk layout separating the
runnable sketch from opdl bookkeeping, opening natively in the Processing PDE **without**
`sketch.properties` — done by naming the sketch folder after its main `.pde`.

This is rev 6, resolving the final review rounds: a fully specified pjs Vite branch (no file moves,
allowlist-only dist copying), a shared pure filename resolver so the folder-name prepass and
`writeCodeFile()` can never disagree (validated `resolvedFileName`, correct bare-/dotfile-extension
handling, explicit dedup-state ownership), and preserved return contracts.

### Confirmed decisions
- **Layout (all modes):** `<outputDir>/sketch/<name>/[sketch files]`. Default `outputDir` stays
  `sketch_<id>`; explicit `--outputDir` used as supplied. Curation independently keeps `<id>_<title>`
  outer dirs → `<id>_<title>/sketch/<name>/`. Bookkeeping (`metadata/`, `LICENSE`,
  `OPENPROCESSING.md`) stays at `<outputDir>/`; code, `index.html`, `style.css`, and assets live
  together in `sketch/<name>/`.
- **pjs (with or without `--vite`):** `.pde` files + `index.html` with `<script src="<engineURL>">`
  and `<canvas data-processing-sources="…">`. One folder that opens in the Processing PDE and in a
  browser. No `sketch.properties`. No inline `text/processing` embedding (avoids `</script>`
  corruption; identical HTML in both modes).
- **pjs + Vite: nothing moves.** All runtime files stay beside the main `.pde` (dual-purpose folder
  preserved); the dev server serves root files as-is; a build plugin copies all runtime files to
  `dist/`. Details below.
- Only pjs changes engine/HTML wiring; p5js / html / applet keep current script wiring, relocated
  into the nested folder.

### Scope note
Tutorial bundles ([tutorialWriter.js](src/download/tutorialWriter.js)) keep their current layout and
`.js` default — out of scope. `writeCodeFile`'s new params are optional so tutorialWriter is
unaffected.

## Behavior spec

Detect pjs via `canonicalizeMode(mode) === 'pjs'` ([sketchMode.js](src/download/sketchMode.js));
covers the `processingjs` alias.

### Shared filename resolver (new)

The downloader must know `sketchDir` before any file is written, but name resolution
(sanitize/fallback/extension/dedupe) currently lives inside `writeCodeFile()`
([codeFileWriter.js:37-52](src/download/codeFileWriter.js#L37-L52)). Extract it:

- **`resolveCodeFileName({ title, index, fallbackBase = 'part', defaultExtension = '.js',
  indexedFallback = true })`** — pure, exported from
  [codeFileWriter.js](src/download/codeFileWriter.js), with real parameter defaults so every
  option is genuinely optional. The extension must be
  captured **before** sanitization, because `path.extname('.pde') === ''` — recomputing it after
  sanitization would misread a sanitized-to-dotfile name as a nonempty basename. Algorithm:

  ```js
  const raw = path.basename(title || '');
  // A title that IS the extension ('.pde', '.PDE') has no stem: path.extname
  // returns '' for dotfiles, so it must be special-cased, not concatenated
  // (naive handling would yield '.pde.pde').
  const isBareExtension = raw.toLowerCase() === defaultExtension.toLowerCase();
  const originalExt = isBareExtension ? defaultExtension : path.extname(raw);
  const intendedExt = originalExt || defaultExtension;
  const rawStem = isBareExtension ? '' : raw.slice(0, raw.length - originalExt.length);
  const fallbackStem = indexedFallback ? `${fallbackBase}_${index + 1}` : fallbackBase;
  const sanitized = sanitizeFilename(`${rawStem}${intendedExt}`);
  const sanitizedStem = sanitized.toLowerCase().endsWith(intendedExt.toLowerCase())
    ? sanitized.slice(0, -intendedExt.length)
    : '';
  return sanitizedStem ? sanitized : `${fallbackStem}${intendedExt}`;
  ```

  So `'***'`, `'.pde'`, and `'.PDE'` (with pjs's `fallbackBase: 'sketch'`,
  `indexedFallback: false`) all resolve to `sketch.pde` instead of a hidden `.pde` file or a
  doubled `.pde.pde`. Empty-stem validation uses the preserved `intendedExt`, never a fresh
  `path.extname()` on the sanitized name. **Deduplication is deliberately not part of the
  resolver** — collisions stay with the existing `dedupeFilename` + `usedNames` at the call sites.
- **Fallback naming is unchanged for existing callers:** the default `indexedFallback: true`
  preserves today's `part_1.js`-style names, so non-pjs behavior only relocates — no filename
  churn for consumers or author HTML. Only the pjs prepass opts into non-indexed `sketch` fallbacks
  (collisions then dedupe to `sketch_2.pde` etc.).
- **Downloader prepass:** map all `codeParts` through `resolveCodeFileName` + `dedupeFilename`
  **once**, producing the final filename list before anything is written. Pass each precomputed name
  into `writeCodeFile` via a new optional `resolvedFileName` param; when omitted (tutorialWriter),
  `writeCodeFile` resolves internally via the same shared function. One code path, no drift.
- **Dedup state is not shared between prepass and writes.** The prepass dedupes against its own
  temporary `Set`; the write loop then starts with a **fresh** `rootUsedNames` exactly as today.
  `writeCodeFile` keeps its existing `dedupeFilename(name, usedNames)` + `usedNames.add(name)`
  behavior even when `resolvedFileName` is provided — since the write loop replays the same names
  in the same order against a fresh set, that dedupe is a no-op on the passed name (reusing the
  prepass set would wrongly bump every name to `_2`), and `rootUsedNames` still ends up populated
  for the downstream asset-collision logic
  ([downloader.js:82-96](src/download/downloader.js#L82-L96)).
- **`resolvedFileName` is validated, never trusted** — `writeCodeFile` is exported, so the param
  must not become a path-traversal hole. `writeCodeFile` rejects (throws on) any `resolvedFileName`
  that is not exactly `path.basename(resolvedFileName)`, not equal to its own
  `sanitizeFilename(...)` form, has an empty stem, or whose `path.resolve(outputDir, name)` does
  not stay inside `outputDir`.
- The folder invariant `folder == main .pde basename` then holds by construction.

### Shared asset filename resolver (new)

Asset naming currently falls back to the **unsanitized** original
(`sanitizeFilename(filename) || path.basename(filename)`), duplicated at
[downloader.js:76](src/download/downloader.js#L76) and inside `buildAssetRenameMap()`
([utils.js:49](src/utils.js#L49)). That fallback can put quotes/backticks/other unsafe characters
on disk — and would contradict the Vite allowlist's sanitization-stability requirement. Replace it
with a shared **`resolveAssetFileName(originalName, index)`** in [utils.js](src/utils.js):
`sanitizeFilename(originalName)`; if the result is empty or not sanitization-stable, fall back to
the safe deterministic `asset_${index + 1}${ext}` (extension taken from the original basename and
itself sanitized, or dropped if unsalvageable). Both `buildAssetRenameMap()` and the downloader's
asset loop call it — they iterate the same `files` array in the same order, so indices and
resulting names agree, and code references are rewritten to the safe name via the existing
`rewriteAssetReferences`. Every on-disk asset name is then sanitization-stable, so it passes the
Vite allowlist check by construction.

### Main file selection (pjs)

`defaultExtension: '.pde'` only affects extensionless tabs — an explicit `helper.js`, `index.html`,
or `style.css` first tab keeps its extension. From the **resolved filename list**, the main PDE
candidate is the first name ending in `.pde` (case-insensitive). Then:
- `<name>` = resolved main filename with its extension removed by actual length
  (`mainPde.slice(0, -path.extname(mainPde).length)`), so an uppercase `.PDE` is stripped
  correctly rather than assuming a lowercase literal.
- The canvas lists **all** `.pde` files in tab order (Processing.js concatenates them). Explicit
  `.js` helper tabs get ordinary `<script src>` tags; CSS keeps its `<link>`.
- **No PDE candidate** (pjs sketch with only `.js`/html/css tabs): folder name from the first
  resolved code filename (fallback `'sketch'`), and `index.html` keeps today's plain `<script src>`
  wiring plus a console warning — degrades to current behavior, no empty canvas.

Non-pjs modes: `<name>` = first resolved code filename minus extension (fallback `'sketch'`).

### pjs index.html

- Head: `<script src="<engineURL>">` + library scripts, as today; `style.css` link kept.
- Body: `<canvas data-processing-sources="a.pde b.pde …">` (tab order); `.js` helpers as plain
  scripts.
- A sketch shipping its own `index.html` code object keeps the existing early-return
  ([htmlGenerator.js:27-31](src/download/htmlGenerator.js#L27-L31)).

### pjs + Vite: complete lifecycle

The generic scaffold moves code to `src/` and assets to `public/`
([viteScaffolder.js:82-143](src/download/viteScaffolder.js#L82-L143)) then rewrites the HTML — both
moves would break the unrewritten pjs HTML and the dual-purpose folder. The pjs branch therefore:

- **Moves nothing.** No `src/`, no `public/`; `.pde`, `.js` helpers, CSS, and downloaded assets all
  stay at the project root (`sketch/<name>/`), so `data-processing-sources`, helper `<script src>`,
  and `loadImage` relative paths resolve unchanged in dev, and the folder still opens in the
  Processing PDE.
- Writes `package.json` + a pjs `vite.config.js`; skips `updateIndexHtmlForVite` and
  `updateHtmlModeFilePaths`.
- **Build copies an explicit runtime allowlist, never "everything".** The sketch dir is not
  guaranteed pristine (repeat downloads, manual edits) — a copy-all rule could publish `.env`,
  `credentials.json`, debug logs, or stale files into `dist/`. Instead the **downloader** assembles
  the runtime file list it actually produced: resolved code filenames (`.pde`/`.js`/`.css`),
  successfully downloaded asset filenames (post conflict-resolution renames), and generated files
  (`style.css`). It passes that list to the scaffolder, which validates it before serialization:
  deduplicate; require each entry to equal `path.basename(entry)`; reject empty or
  sanitization-unstable names; explicitly exclude `index.html` (Vite owns it). The validated list is 
  embedded via **`JSON.stringify(runtimeFiles)`**, never hand-built quoting, as an additional safeguard 
  against invalid generated JavaScript. The inline `closeBundle`
  plugin (no new dependency) copies **only those entries** into `dist/`, and additionally verifies
  at copy time that each resolved source stays within the project root and each destination within
  `dist/`. Files absent at build time are skipped with a warning rather than failing the build.
- **Completion message** ([viteScaffolder.js:169-171](src/download/viteScaffolder.js#L169-L171)):
  `path.basename(outputDir)` would print a bare `<name>`; print
  `cd <path.relative(process.cwd(), sketchDir)> && npm run dev` (absolute path if the relative one
  escapes upward), with the path **shell-quoted** (single quotes, `'` escaped) so directories
  containing spaces produce a runnable command.

### Return contracts

- `downloadSketch` returns `{ outputDir, metadataDir, sketchDir, sketchName, codeFiles }` —
  **`metadataDir` preserved** from the current contract
  ([downloader.js:202](src/download/downloader.js#L202)).
- Public `opdl()` result ([index.js](src/index.js)): initialize `sketchName: null` and
  `sketchPath: null` in the result skeleton (predictable shape on error/unavailable), then set them
  from `downloadResult.sketchName` / `downloadResult.sketchDir` on success. Manifests store only
  `sketchName`, never a path.

## Changes

- **[downloader.js](src/download/downloader.js)** — compute `isPjs`; run the resolver prepass; pick
  the main PDE candidate; derive `sketchName` and `sketchDir = path.join(outputDir, 'sketch',
  sketchName)`; route code writing (passing `resolvedFileName` and `defaultExtension: isPjs ? '.pde'
  : '.js'`), asset downloads, `generateIndexHtml`, and `style.css` to `sketchDir`; keep `metadata/`,
  license, op-metadata at `outputDir`. Track the runtime file list (written code files, downloaded
  asset names, generated `style.css`) and pass it to the Vite scaffolder for the build allowlist.
  `--run` (non-vite) serves `sketchDir`; `--vite` scaffolds in `sketchDir`. Return contract above.
- **[index.js](src/index.js)** — result skeleton + propagation per Return contracts.
- **[utils.js](src/utils.js)** — add `resolveAssetFileName`; `buildAssetRenameMap()` and the
  downloader's asset loop both use it (replacing the duplicated unsafe `|| path.basename`
  fallback).
- **[codeFileWriter.js](src/download/codeFileWriter.js)** — extract/export `resolveCodeFileName`
  (extension captured pre-sanitization, per spec); add optional `resolvedFileName` and
  `defaultExtension` params; `resolvedFileName` is validated (basename-only, sanitization-stable,
  nonempty stem, resolves inside `outputDir`) and rejected otherwise; internal path delegates to
  the shared resolver.
- **[htmlGenerator.js](src/download/htmlGenerator.js)** — pjs branch: `.pde` parts → canvas form;
  `.js` parts keep `<script src>`; zero `.pde` parts → current wiring + warning; early return,
  engine, libraries, CSS link preserved; p5js unchanged.
- **[viteScaffolder.js](src/download/viteScaffolder.js)** — operate on `sketchDir`; pjs branch per
  lifecycle spec, accepting the runtime file list and baking it into the generated
  `vite.config.js` copy plugin; p5js/html keep current behavior rooted at `sketchDir`; completion
  message fix.
- **[codeAttributor.js](src/download/codeAttributor.js)** — add `.pde` to `ATTRIBUTION_EXTENSIONS`
  (line 23; C-style header is valid Processing).
- **[curationDownloader.js](src/download/curationDownloader.js)** — manifest entry gains
  `sketchName: result.sketchName` (from the public `opdl()` result); `indexPath` becomes
  `public/sketches/<dir>/sketch/<name>/index.html`; `thumbnailPath`/metadata unchanged (still at
  `<dir>/metadata/`). Skipped sketches: `existingManifestEntry` reads `<outputDir>/sketch/`,
  filters to **directories only** (ignores `.DS_Store` etc.); exactly one child dir → its name;
  missing/empty/multiple → omit `sketchName` (legacy fallback).
- **[templates/gallery/main.js](src/download/templates/gallery/main.js)** — `sketchUrl()`
  ([line 243](src/download/templates/gallery/main.js#L243)): with `sketchName`, return
  `./sketches/${encodeURIComponent(project.dir)}/sketch/${encodeURIComponent(project.sketchName)}/index.html`;
  otherwise the current legacy URL. `thumbUrl()`/`resolveDir()` unchanged.
- **Docs** ([HELP.md](HELP.md), [README.md](README.md), [AGENTS.md](AGENTS.md)) — nested
  `<outputDir>/sketch/<name>/` layout (default outer dir still `sketch_<id>`; curations
  `<id>_<title>/sketch/<name>/`); Vite instruction `cd <outputDir>/sketch/<name> && npm run dev`;
  pjs dual-purpose behavior; note browser-only JS helpers won't run in the Processing PDE.

## Tests (vitest)

- `codeFileWriter.test.mjs` — `resolveCodeFileName` (pure, no dedup assertions): missing title,
  punctuation-only extensionless title, `'***.pde'` → `sketch.pde` (non-indexed pjs fallback),
  literal `'.pde'` title, uppercase `'.PDE'` extension, explicit extensions preserved, indexed
  default fallback still yields `part_1.js`; `writeCodeFile` honors `resolvedFileName` and
  `defaultExtension`, and **rejects invalid `resolvedFileName`**: `../../evil.js` and other
  traversal forms, absolute paths, names differing from their sanitized form, empty-stem names.
- `htmlGenerator.test.mjs` — pjs canvas form, tab order, no code `<script src>` for `.pde`;
  `processingjs` alias; `.js` helper excluded from canvas but kept as script; zero `.pde` →
  fallback wiring + warning; existing-index.html early return; p5js unchanged.
- `downloader.test.mjs` — nested layout; `metadata/`/`LICENSE` at top; main-PDE selection when tab 0
  is an explicit `.js`/`index.html`/`.css`; folder == main `.pde` incl. the `'***'` fallback case;
  **prepass collision handling** (two tabs resolving to the same name dedupe consistently between
  the predicted list and the files on disk); no `sketch.properties`; `.pde` attribution; return
  carries `{ outputDir, metadataDir, sketchDir, sketchName, codeFiles }`.
- `index.test.mjs` — result exposes `sketchName`/`sketchPath` on success and `null` on
  error/unavailable; "processingjs" case updated to nested `.pde` + canvas HTML.
- `curationDownloader.test.mjs` — manifest `sketchName` + nested `indexPath`; skipped-entry
  recovery from disk; legacy/ambiguous layouts omit `sketchName`.
- Gallery test — `sketchUrl()` nested path with both segments encoded; legacy fallback.
- `utils` test — `resolveAssetFileName`: normal names pass through sanitized; quotes/backticks or
  sanitize-to-empty originals become `asset_<n>.<ext>`; `buildAssetRenameMap` and the downloader
  agree on the resulting names (rename map entry matches the file written to disk, and code
  references are rewritten to it).
- `viteScaffolder.test.mjs` — pjs fixture with **a `.pde`, a `.js` helper, a `.css`, and a
  downloaded image**: all remain at the project root (no `src/`/`public/`), index.html unrewritten,
  `vite.config.js` contains the copy plugin with exactly the allowlisted runtime files — and a
  planted `.env` in the fixture is **not** in the allowlist; an asset originally named with quotes
  and backticks resolves (via `resolveAssetFileName`) to a safe deterministic filename that appears
  in the allowlist, the generated config stays syntactically valid (parseable / importable), and
  only that file is copied; completion message prints the full, shell-quoted `cd` path; p5js vite
  still scaffolds rooted at `sketchDir`.
- **Vite build integration test** (same fixture, plus a planted `.env`): run `npm install` +
  `npm run build` in a temp dir and assert `dist/` contains `index.html`, every `.pde`, the `.js`
  helper, and the image — and does **not** contain `.env`. **Opt-in only** — gated behind
  `OPDL_INTEGRATION=1` so the default `npm test` stays deterministic and never runs `npm install`;
  manual build verification (step 5 below) covers it otherwise.
- Existing download/curation/index tests updated for the nested paths (no fallback-name changes for
  non-pjs callers).

## Verification (test sketch 2045070 first, per request)

1. `node bin/opdl.js 2045070 --outputDir /tmp/pjs_2045070` — confirm
   `pjs_2045070/sketch/<name>/{<name>.pde, index.html, style.css}`,
   `pjs_2045070/{metadata,LICENSE,OPENPROCESSING.md}`, engine `<script>` +
   `<canvas data-processing-sources>`, no `sketch.properties`.
2. Browser: `--run` (serves `sketch/<name>/`) renders.
3. Processing PDE: open `sketch/<name>/<name>.pde`, runs natively.
4. Asset-bearing pjs sketch (find one via the API if 2045070 has none): asset resolves in browser
   (`--run`) and in the Processing PDE.
5. `node bin/opdl.js 2045070 --vite --outputDir /tmp/pjs_vite` — `.pde`/assets at project root,
   `npm run dev` renders, `npm run build` → `dist/` contains index.html + all `.pde` + assets +
   helpers, completion message prints the correct `cd` path.
6. `npm test` — all default suites green (build integration test excluded by design), then
   `OPDL_INTEGRATION=1 npm test` for the Vite build integration test.
7. Curation: `node bin/opdl.js curation download <id> --mode pjs --outputDir /tmp/cur_check --run` —
   pjs sketch renders in the gallery; re-run with skip to confirm skipped-entry `sketchName`
   recovery.
